### PR TITLE
NLD is all DVB-T2

### DIFF
--- a/xml/terrestrial.xml
+++ b/xml/terrestrial.xml
@@ -2515,497 +2515,180 @@
 		<transponder centre_frequency="850000000" bandwidth="0" constellation="2" code_rate_hp="6" code_rate_lp="6" guard_interval="0" transmission_mode="1" hierarchy_information="0" inversion="2"/>
 		<transponder centre_frequency="858000000" bandwidth="0" constellation="2" code_rate_hp="6" code_rate_lp="6" guard_interval="0" transmission_mode="1" hierarchy_information="0" inversion="2"/>
 	</terrestrial>
-	<terrestrial name="Digitenne (Europe DVB-T/T2)" flags="5" countrycode="NLD">
-		<transponder centre_frequency="474000000" bandwidth="0" constellation="2" code_rate_hp="0" code_rate_lp="6" guard_interval="3" transmission_mode="1" hierarchy_information="0" inversion="2"/>
-		<transponder centre_frequency="482000000" bandwidth="0" constellation="2" code_rate_hp="0" code_rate_lp="6" guard_interval="3" transmission_mode="1" hierarchy_information="0" inversion="2"/>
-		<transponder centre_frequency="490000000" bandwidth="0" constellation="2" code_rate_hp="0" code_rate_lp="6" guard_interval="3" transmission_mode="1" hierarchy_information="0" inversion="2"/>
-		<transponder centre_frequency="498000000" bandwidth="0" constellation="2" code_rate_hp="0" code_rate_lp="6" guard_interval="3" transmission_mode="1" hierarchy_information="0" inversion="2"/>
-		<transponder centre_frequency="506000000" bandwidth="0" constellation="2" code_rate_hp="0" code_rate_lp="6" guard_interval="3" transmission_mode="1" hierarchy_information="0" inversion="2"/>
-		<transponder centre_frequency="514000000" bandwidth="0" constellation="2" code_rate_hp="0" code_rate_lp="6" guard_interval="3" transmission_mode="1" hierarchy_information="0" inversion="2"/>
-		<transponder centre_frequency="522000000" bandwidth="0" constellation="2" code_rate_hp="0" code_rate_lp="6" guard_interval="3" transmission_mode="1" hierarchy_information="0" inversion="2"/>
-		<transponder centre_frequency="530000000" bandwidth="0" constellation="2" code_rate_hp="0" code_rate_lp="6" guard_interval="3" transmission_mode="1" hierarchy_information="0" inversion="2"/>
-		<transponder centre_frequency="538000000" bandwidth="0" constellation="2" code_rate_hp="0" code_rate_lp="6" guard_interval="3" transmission_mode="1" hierarchy_information="0" inversion="2"/>
-		<transponder centre_frequency="546000000" bandwidth="0" constellation="2" code_rate_hp="0" code_rate_lp="6" guard_interval="3" transmission_mode="1" hierarchy_information="0" inversion="2"/>
-		<transponder centre_frequency="554000000" bandwidth="0" constellation="2" code_rate_hp="0" code_rate_lp="6" guard_interval="3" transmission_mode="1" hierarchy_information="0" inversion="2"/>
-		<transponder centre_frequency="562000000" bandwidth="0" constellation="2" code_rate_hp="0" code_rate_lp="6" guard_interval="3" transmission_mode="1" hierarchy_information="0" inversion="2"/>
-		<transponder centre_frequency="570000000" bandwidth="0" constellation="2" code_rate_hp="0" code_rate_lp="6" guard_interval="3" transmission_mode="1" hierarchy_information="0" inversion="2"/>
-		<transponder centre_frequency="578000000" bandwidth="0" constellation="2" code_rate_hp="0" code_rate_lp="6" guard_interval="3" transmission_mode="1" hierarchy_information="0" inversion="2"/>
-		<transponder centre_frequency="586000000" bandwidth="0" constellation="2" code_rate_hp="0" code_rate_lp="6" guard_interval="3" transmission_mode="1" hierarchy_information="0" inversion="2"/>
-		<transponder centre_frequency="594000000" bandwidth="0" constellation="2" code_rate_hp="0" code_rate_lp="6" guard_interval="3" transmission_mode="1" hierarchy_information="0" inversion="2"/>
-		<transponder centre_frequency="602000000" bandwidth="0" constellation="2" code_rate_hp="0" code_rate_lp="6" guard_interval="3" transmission_mode="1" hierarchy_information="0" inversion="2"/>
-		<transponder centre_frequency="610000000" bandwidth="0" constellation="2" code_rate_hp="0" code_rate_lp="6" guard_interval="3" transmission_mode="1" hierarchy_information="0" inversion="2"/>
-		<transponder centre_frequency="618000000" bandwidth="0" constellation="2" code_rate_hp="0" code_rate_lp="6" guard_interval="3" transmission_mode="1" hierarchy_information="0" inversion="2"/>
-		<transponder centre_frequency="626000000" bandwidth="0" constellation="2" code_rate_hp="0" code_rate_lp="6" guard_interval="3" transmission_mode="1" hierarchy_information="0" inversion="2"/>
-		<transponder centre_frequency="634000000" bandwidth="0" constellation="2" code_rate_hp="0" code_rate_lp="6" guard_interval="3" transmission_mode="1" hierarchy_information="0" inversion="2"/>
-		<transponder centre_frequency="642000000" bandwidth="0" constellation="2" code_rate_hp="0" code_rate_lp="6" guard_interval="3" transmission_mode="1" hierarchy_information="0" inversion="2"/>
-		<transponder centre_frequency="650000000" bandwidth="0" constellation="2" code_rate_hp="0" code_rate_lp="6" guard_interval="3" transmission_mode="1" hierarchy_information="0" inversion="2"/>
-		<transponder centre_frequency="658000000" bandwidth="0" constellation="2" code_rate_hp="0" code_rate_lp="6" guard_interval="3" transmission_mode="1" hierarchy_information="0" inversion="2"/>
-		<transponder centre_frequency="666000000" bandwidth="0" constellation="2" code_rate_hp="0" code_rate_lp="6" guard_interval="3" transmission_mode="1" hierarchy_information="0" inversion="2"/>
-		<transponder centre_frequency="674000000" bandwidth="0" constellation="2" code_rate_hp="0" code_rate_lp="6" guard_interval="3" transmission_mode="1" hierarchy_information="0" inversion="2"/>
-		<transponder centre_frequency="682000000" bandwidth="0" constellation="2" code_rate_hp="0" code_rate_lp="6" guard_interval="3" transmission_mode="1" hierarchy_information="0" inversion="2"/>
-		<transponder centre_frequency="690000000" bandwidth="0" constellation="2" code_rate_hp="0" code_rate_lp="6" guard_interval="3" transmission_mode="1" hierarchy_information="0" inversion="2"/>
-		<transponder centre_frequency="698000000" bandwidth="0" constellation="2" code_rate_hp="0" code_rate_lp="6" guard_interval="3" transmission_mode="1" hierarchy_information="0" inversion="2"/>
-		<transponder centre_frequency="706000000" bandwidth="0" constellation="2" code_rate_hp="0" code_rate_lp="6" guard_interval="3" transmission_mode="1" hierarchy_information="0" inversion="2"/>
-		<transponder centre_frequency="714000000" bandwidth="0" constellation="2" code_rate_hp="0" code_rate_lp="6" guard_interval="3" transmission_mode="1" hierarchy_information="0" inversion="2"/>
-		<transponder centre_frequency="722000000" bandwidth="0" constellation="2" code_rate_hp="0" code_rate_lp="6" guard_interval="3" transmission_mode="1" hierarchy_information="0" inversion="2"/>
-		<transponder centre_frequency="730000000" bandwidth="0" constellation="2" code_rate_hp="0" code_rate_lp="6" guard_interval="3" transmission_mode="1" hierarchy_information="0" inversion="2"/>
-		<transponder centre_frequency="738000000" bandwidth="0" constellation="2" code_rate_hp="0" code_rate_lp="6" guard_interval="3" transmission_mode="1" hierarchy_information="0" inversion="2"/>
-		<transponder centre_frequency="746000000" bandwidth="0" constellation="2" code_rate_hp="0" code_rate_lp="6" guard_interval="3" transmission_mode="1" hierarchy_information="0" inversion="2"/>
-		<transponder centre_frequency="754000000" bandwidth="0" constellation="2" code_rate_hp="0" code_rate_lp="6" guard_interval="3" transmission_mode="1" hierarchy_information="0" inversion="2"/>
-		<transponder centre_frequency="762000000" bandwidth="0" constellation="2" code_rate_hp="0" code_rate_lp="6" guard_interval="3" transmission_mode="1" hierarchy_information="0" inversion="2"/>
-		<transponder centre_frequency="770000000" bandwidth="0" constellation="2" code_rate_hp="0" code_rate_lp="6" guard_interval="3" transmission_mode="1" hierarchy_information="0" inversion="2"/>
-		<transponder centre_frequency="778000000" bandwidth="0" constellation="2" code_rate_hp="0" code_rate_lp="6" guard_interval="3" transmission_mode="1" hierarchy_information="0" inversion="2"/>
-		<transponder centre_frequency="786000000" bandwidth="0" constellation="2" code_rate_hp="0" code_rate_lp="6" guard_interval="3" transmission_mode="1" hierarchy_information="0" inversion="2"/>
-		<transponder centre_frequency="818000000" bandwidth="0" constellation="2" code_rate_hp="0" code_rate_lp="6" guard_interval="3" transmission_mode="1" hierarchy_information="0" inversion="2"/>
+	<terrestrial name="Digitenne (Europe DVB-T2)" flags="5" countrycode="NLD">
+		<transponder centre_frequency="474000000" bandwidth="0" system="1" constellation="4" code_rate_hp="5" code_rate_lp="5" guard_interval="2" transmission_mode="6" hierarchy_information="4" inversion="2"/>
+		<transponder centre_frequency="482000000" bandwidth="0" system="1" constellation="4" code_rate_hp="5" code_rate_lp="5" guard_interval="2" transmission_mode="6" hierarchy_information="4" inversion="2"/>
+		<transponder centre_frequency="490000000" bandwidth="0" system="1" constellation="4" code_rate_hp="5" code_rate_lp="5" guard_interval="2" transmission_mode="6" hierarchy_information="4" inversion="2"/>
+		<transponder centre_frequency="498000000" bandwidth="0" system="1" constellation="4" code_rate_hp="5" code_rate_lp="5" guard_interval="2" transmission_mode="6" hierarchy_information="4" inversion="2"/>
+		<transponder centre_frequency="506000000" bandwidth="0" system="1" constellation="4" code_rate_hp="5" code_rate_lp="5" guard_interval="2" transmission_mode="6" hierarchy_information="4" inversion="2"/>
+		<transponder centre_frequency="514000000" bandwidth="0" system="1" constellation="4" code_rate_hp="5" code_rate_lp="5" guard_interval="2" transmission_mode="6" hierarchy_information="4" inversion="2"/>
+		<transponder centre_frequency="522000000" bandwidth="0" system="1" constellation="4" code_rate_hp="5" code_rate_lp="5" guard_interval="2" transmission_mode="6" hierarchy_information="4" inversion="2"/>
+		<transponder centre_frequency="530000000" bandwidth="0" system="1" constellation="4" code_rate_hp="5" code_rate_lp="5" guard_interval="2" transmission_mode="6" hierarchy_information="4" inversion="2"/>
+		<transponder centre_frequency="538000000" bandwidth="0" system="1" constellation="4" code_rate_hp="5" code_rate_lp="5" guard_interval="2" transmission_mode="6" hierarchy_information="4" inversion="2"/>
+		<transponder centre_frequency="546000000" bandwidth="0" system="1" constellation="4" code_rate_hp="5" code_rate_lp="5" guard_interval="2" transmission_mode="6" hierarchy_information="4" inversion="2"/>
+		<transponder centre_frequency="554000000" bandwidth="0" system="1" constellation="4" code_rate_hp="5" code_rate_lp="5" guard_interval="2" transmission_mode="6" hierarchy_information="4" inversion="2"/>
+		<transponder centre_frequency="562000000" bandwidth="0" system="1" constellation="4" code_rate_hp="5" code_rate_lp="5" guard_interval="2" transmission_mode="6" hierarchy_information="4" inversion="2"/>
+		<transponder centre_frequency="570000000" bandwidth="0" system="1" constellation="4" code_rate_hp="5" code_rate_lp="5" guard_interval="2" transmission_mode="6" hierarchy_information="4" inversion="2"/>
+		<transponder centre_frequency="578000000" bandwidth="0" system="1" constellation="4" code_rate_hp="5" code_rate_lp="5" guard_interval="2" transmission_mode="6" hierarchy_information="4" inversion="2"/>
+		<transponder centre_frequency="586000000" bandwidth="0" system="1" constellation="4" code_rate_hp="5" code_rate_lp="5" guard_interval="2" transmission_mode="6" hierarchy_information="4" inversion="2"/>
+		<transponder centre_frequency="594000000" bandwidth="0" system="1" constellation="4" code_rate_hp="5" code_rate_lp="5" guard_interval="2" transmission_mode="6" hierarchy_information="4" inversion="2"/>
+		<transponder centre_frequency="602000000" bandwidth="0" system="1" constellation="4" code_rate_hp="5" code_rate_lp="5" guard_interval="2" transmission_mode="6" hierarchy_information="4" inversion="2"/>
+		<transponder centre_frequency="610000000" bandwidth="0" system="1" constellation="4" code_rate_hp="5" code_rate_lp="5" guard_interval="2" transmission_mode="6" hierarchy_information="4" inversion="2"/>
+		<transponder centre_frequency="618000000" bandwidth="0" system="1" constellation="4" code_rate_hp="5" code_rate_lp="5" guard_interval="2" transmission_mode="6" hierarchy_information="4" inversion="2"/>
+		<transponder centre_frequency="626000000" bandwidth="0" system="1" constellation="4" code_rate_hp="5" code_rate_lp="5" guard_interval="2" transmission_mode="6" hierarchy_information="4" inversion="2"/>
+		<transponder centre_frequency="634000000" bandwidth="0" system="1" constellation="4" code_rate_hp="5" code_rate_lp="5" guard_interval="2" transmission_mode="6" hierarchy_information="4" inversion="2"/>
+		<transponder centre_frequency="642000000" bandwidth="0" system="1" constellation="4" code_rate_hp="5" code_rate_lp="5" guard_interval="2" transmission_mode="6" hierarchy_information="4" inversion="2"/>
+		<transponder centre_frequency="650000000" bandwidth="0" system="1" constellation="4" code_rate_hp="5" code_rate_lp="5" guard_interval="2" transmission_mode="6" hierarchy_information="4" inversion="2"/>
+		<transponder centre_frequency="658000000" bandwidth="0" system="1" constellation="4" code_rate_hp="5" code_rate_lp="5" guard_interval="2" transmission_mode="6" hierarchy_information="4" inversion="2"/>
+		<transponder centre_frequency="666000000" bandwidth="0" system="1" constellation="4" code_rate_hp="5" code_rate_lp="5" guard_interval="2" transmission_mode="6" hierarchy_information="4" inversion="2"/>
+		<transponder centre_frequency="674000000" bandwidth="0" system="1" constellation="4" code_rate_hp="5" code_rate_lp="5" guard_interval="2" transmission_mode="6" hierarchy_information="4" inversion="2"/>
+		<transponder centre_frequency="682000000" bandwidth="0" system="1" constellation="4" code_rate_hp="5" code_rate_lp="5" guard_interval="2" transmission_mode="6" hierarchy_information="4" inversion="2"/>
+		<transponder centre_frequency="690000000" bandwidth="0" system="1" constellation="4" code_rate_hp="5" code_rate_lp="5" guard_interval="2" transmission_mode="6" hierarchy_information="4" inversion="2"/>
+		<transponder centre_frequency="746000000" bandwidth="0" system="1" constellation="4" code_rate_hp="5" code_rate_lp="5" guard_interval="2" transmission_mode="6" hierarchy_information="4" inversion="2"/>
 	</terrestrial>
-	<terrestrial name="Alkmaar (Europe DVB-T/T2)" flags="5" countrycode="NLD">
-		<transponder centre_frequency="306000000" bandwidth="0" system="0"/>
-		<transponder centre_frequency="618000000" bandwidth="0" system="0"/>
-		<transponder centre_frequency="666000000" bandwidth="0" system="0"/>
-		<transponder centre_frequency="578000000" bandwidth="0" system="0"/>
-		<transponder centre_frequency="586000000" bandwidth="0" system="0"/>
-		<transponder centre_frequency="658000000" bandwidth="0" system="0"/>
+	<terrestrial name="Groningen/Friesland (Europe DVB-T2)" flags="5" countrycode="NLD">
+		<transponder centre_frequency="474000000" bandwidth="0" system="1"/>
+		<transponder centre_frequency="482000000" bandwidth="0" system="1"/>
+		<transponder centre_frequency="506000000" bandwidth="0" system="1"/>
+		<transponder centre_frequency="514000000" bandwidth="0" system="1"/>
+		<transponder centre_frequency="570000000" bandwidth="0" system="1"/>
+		<transponder centre_frequency="578000000" bandwidth="0" system="1"/>
+		<transponder centre_frequency="626000000" bandwidth="0" system="1"/>
+		<transponder centre_frequency="674000000" bandwidth="0" system="1"/>
 	</terrestrial>
-	<terrestrial name="Almere (Europe DVB-T/T2)" flags="5" countrycode="NLD">
-		<transponder centre_frequency="306000000" bandwidth="0" system="0"/>
-		<transponder centre_frequency="514000000" bandwidth="0" system="0"/>
-		<transponder centre_frequency="698000000" bandwidth="0" system="0"/>
-		<transponder centre_frequency="762000000" bandwidth="0" system="0"/>
-		<transponder centre_frequency="498000000" bandwidth="0" system="0"/>
-		<transponder centre_frequency="522000000" bandwidth="0" system="0"/>
+	<terrestrial name="Drenthe (Europe DVB-T2)" flags="5" countrycode="NLD">
+		<transponder centre_frequency="474000000" bandwidth="0" system="1"/>
+		<transponder centre_frequency="506000000" bandwidth="0" system="1"/>
+		<transponder centre_frequency="514000000" bandwidth="0" system="1"/>
+		<transponder centre_frequency="570000000" bandwidth="0" system="1"/>
+		<transponder centre_frequency="626000000" bandwidth="0" system="1"/>
+		<transponder centre_frequency="674000000" bandwidth="0" system="1"/>
+		<transponder centre_frequency="482000000" bandwidth="0" system="1"/>
 	</terrestrial>
-	<terrestrial name="Alphen aan den Rijn (Europe DVB-T/T2)" flags="5" countrycode="NLD">
-		<transponder centre_frequency="306000000" bandwidth="0" system="0"/>
-		<transponder centre_frequency="722000000" bandwidth="0" system="0"/>
-		<transponder centre_frequency="698000000" bandwidth="0" system="0"/>
-		<transponder centre_frequency="762000000" bandwidth="0" system="0"/>
-		<transponder centre_frequency="498000000" bandwidth="0" system="0"/>
-		<transponder centre_frequency="522000000" bandwidth="0" system="0"/>
+	<terrestrial name="Overijssel (Europe DVB-T2)" flags="5" countrycode="NLD">
+		<transponder centre_frequency="490000000" bandwidth="0" system="1"/>
+		<transponder centre_frequency="514000000" bandwidth="0" system="1"/>
+		<transponder centre_frequency="578000000" bandwidth="0" system="1"/>
+		<transponder centre_frequency="594000000" bandwidth="0" system="1"/>
+		<transponder centre_frequency="618000000" bandwidth="0" system="1"/>
+		<transponder centre_frequency="482000000" bandwidth="0" system="1"/>
+		<transponder centre_frequency="626000000" bandwidth="0" system="1"/>
+		<transponder centre_frequency="658000000" bandwidth="0" system="1"/>
+		<transponder centre_frequency="682000000" bandwidth="0" system="1"/>
 	</terrestrial>
-	<terrestrial name="Amersfoort (Europe DVB-T/T2)" flags="5" countrycode="NLD">
-		<transponder centre_frequency="306000000" bandwidth="0" system="0"/>
-		<transponder centre_frequency="706000000" bandwidth="0" system="0"/>
-		<transponder centre_frequency="698000000" bandwidth="0" system="0"/>
-		<transponder centre_frequency="762000000" bandwidth="0" system="0"/>
-		<transponder centre_frequency="498000000" bandwidth="0" system="0"/>
-		<transponder centre_frequency="522000000" bandwidth="0" system="0"/>
+	<terrestrial name="Flevoland (Europe DVB-T2)" flags="5" countrycode="NLD">
+		<transponder centre_frequency="482000000" bandwidth="0" system="1"/>
+		<transponder centre_frequency="490000000" bandwidth="0" system="1"/>
+		<transponder centre_frequency="570000000" bandwidth="0" system="1"/>
+		<transponder centre_frequency="578000000" bandwidth="0" system="1"/>
+		<transponder centre_frequency="594000000" bandwidth="0" system="1"/>
+		<transponder centre_frequency="618000000" bandwidth="0" system="1"/>
+		<transponder centre_frequency="514000000" bandwidth="0" system="1"/>
+		<transponder centre_frequency="658000000" bandwidth="0" system="1"/>
+		<transponder centre_frequency="666000000" bandwidth="0" system="1"/>
+		<transponder centre_frequency="682000000" bandwidth="0" system="1"/>
+		<transponder centre_frequency="522000000" bandwidth="0" system="1"/>
+		<transponder centre_frequency="562000000" bandwidth="0" system="1"/>
+		<transponder centre_frequency="498000000" bandwidth="0" system="1"/>
 	</terrestrial>
-	<terrestrial name="Amsterdam Hemweg (Europe DVB-T/T2)" flags="5" countrycode="NLD">
-		<transponder centre_frequency="306000000" bandwidth="0" system="0"/>
-		<transponder centre_frequency="618000000" bandwidth="0" system="0"/>
-		<transponder centre_frequency="698000000" bandwidth="0" system="0"/>
-		<transponder centre_frequency="762000000" bandwidth="0" system="0"/>
-		<transponder centre_frequency="498000000" bandwidth="0" system="0"/>
-		<transponder centre_frequency="522000000" bandwidth="0" system="0"/>
+	<terrestrial name="Gelderland (Europe DVB-T2)" flags="5" countrycode="NLD">
+		<transponder centre_frequency="474000000" bandwidth="0" system="1"/>
+		<transponder centre_frequency="482000000" bandwidth="0" system="1"/>
+		<transponder centre_frequency="490000000" bandwidth="0" system="1"/>
+		<transponder centre_frequency="562000000" bandwidth="0" system="1"/>
+		<transponder centre_frequency="570000000" bandwidth="0" system="1"/>
+		<transponder centre_frequency="578000000" bandwidth="0" system="1"/>
+		<transponder centre_frequency="618000000" bandwidth="0" system="1"/>
+		<transponder centre_frequency="514000000" bandwidth="0" system="1"/>
+		<transponder centre_frequency="658000000" bandwidth="0" system="1"/>
+		<transponder centre_frequency="682000000" bandwidth="0" system="1"/>
+		<transponder centre_frequency="498000000" bandwidth="0" system="1"/>
+		<transponder centre_frequency="530000000" bandwidth="0" system="1"/>
+		<transponder centre_frequency="546000000" bandwidth="0" system="1"/>
+		<transponder centre_frequency="554000000" bandwidth="0" system="1"/>
+		<transponder centre_frequency="594000000" bandwidth="0" system="1"/>
+		<transponder centre_frequency="642000000" bandwidth="0" system="1"/>
 	</terrestrial>
-	<terrestrial name="Amsterdam Rai (Europe DVB-T/T2)" flags="5" countrycode="NLD">
-		<transponder centre_frequency="306000000" bandwidth="0" system="0"/>
-		<transponder centre_frequency="618000000" bandwidth="0" system="0"/>
-		<transponder centre_frequency="698000000" bandwidth="0" system="0"/>
-		<transponder centre_frequency="762000000" bandwidth="0" system="0"/>
-		<transponder centre_frequency="498000000" bandwidth="0" system="0"/>
-		<transponder centre_frequency="522000000" bandwidth="0" system="0"/>
+	<terrestrial name="Noord Holland (Europe DVB-T2)" flags="5" countrycode="NLD">
+		<transponder centre_frequency="474000000" bandwidth="0" system="1"/>
+		<transponder centre_frequency="482000000" bandwidth="0" system="1"/>
+		<transponder centre_frequency="490000000" bandwidth="0" system="1"/>
+		<transponder centre_frequency="498000000" bandwidth="0" system="1"/>
+		<transponder centre_frequency="514000000" bandwidth="0" system="1"/>
+		<transponder centre_frequency="594000000" bandwidth="0" system="1"/>
+		<transponder centre_frequency="562000000" bandwidth="0" system="1"/>
+		<transponder centre_frequency="618000000" bandwidth="0" system="1"/>
+		<transponder centre_frequency="658000000" bandwidth="0" system="1"/>
+		<transponder centre_frequency="666000000" bandwidth="0" system="1"/>
+		<transponder centre_frequency="682000000" bandwidth="0" system="1"/>
+		<transponder centre_frequency="522000000" bandwidth="0" system="1"/>
+		<transponder centre_frequency="578000000" bandwidth="0" system="1"/>
 	</terrestrial>
-	<terrestrial name="Apeldoorn (Europe DVB-T/T2)" flags="5" countrycode="NLD">
-		<transponder centre_frequency="306000000" bandwidth="0" system="0"/>
-		<transponder centre_frequency="642000000" bandwidth="0" system="0"/>
-		<transponder centre_frequency="594000000" bandwidth="0" system="0"/>
-		<transponder centre_frequency="770000000" bandwidth="0" system="0"/>
-		<transponder centre_frequency="730000000" bandwidth="0" system="0"/>
-		<transponder centre_frequency="530000000" bandwidth="0" system="0"/>
+	<terrestrial name="Texel/Vlieland (Europe DVB-T2)" flags="5" countrycode="NLD">
+		<transponder centre_frequency="626000000" bandwidth="0" system="1"/>
+		<transponder centre_frequency="514000000" bandwidth="0" system="1"/>
+		<transponder centre_frequency="538000000" bandwidth="0" system="1"/>
+		<transponder centre_frequency="554000000" bandwidth="0" system="1"/>
+		<transponder centre_frequency="578000000" bandwidth="0" system="1"/>
+		<transponder centre_frequency="586000000" bandwidth="0" system="1"/>
+		<transponder centre_frequency="602000000" bandwidth="0" system="1"/>
 	</terrestrial>
-	<terrestrial name="Arnhem (Europe DVB-T/T2)" flags="5" countrycode="NLD">
-		<transponder centre_frequency="306000000" bandwidth="0" system="0"/>
-		<transponder centre_frequency="642000000" bandwidth="0" system="0"/>
-		<transponder centre_frequency="594000000" bandwidth="0" system="0"/>
-		<transponder centre_frequency="770000000" bandwidth="0" system="0"/>
-		<transponder centre_frequency="730000000" bandwidth="0" system="0"/>
-		<transponder centre_frequency="530000000" bandwidth="0" system="0"/>
+	<terrestrial name="Utrecht/Zuid Holland Noord (Europe DVB-T2)" flags="5" countrycode="NLD">	
+		<transponder centre_frequency="474000000" bandwidth="0" system="1"/>
+		<transponder centre_frequency="482000000" bandwidth="0" system="1"/>
+		<transponder centre_frequency="498000000" bandwidth="0" system="1"/>
+		<transponder centre_frequency="514000000" bandwidth="0" system="1"/>
+		<transponder centre_frequency="522000000" bandwidth="0" system="1"/>
+		<transponder centre_frequency="562000000" bandwidth="0" system="1"/>
+		<transponder centre_frequency="570000000" bandwidth="0" system="1"/>
+		<transponder centre_frequency="578000000" bandwidth="0" system="1"/>
+		<transponder centre_frequency="618000000" bandwidth="0" system="1"/>
+		<transponder centre_frequency="666000000" bandwidth="0" system="1"/>
+	</terrestrial>	
+	<terrestrial name="Zuid Holland Zuid (Europe DVB-T2)" flags="5" countrycode="NLD">
+		<transponder centre_frequency="498000000" bandwidth="0" system="1"/>
+		<transponder centre_frequency="514000000" bandwidth="0" system="1"/>
+		<transponder centre_frequency="538000000" bandwidth="0" system="1"/>
+		<transponder centre_frequency="562000000" bandwidth="0" system="1"/>
+		<transponder centre_frequency="570000000" bandwidth="0" system="1"/>
+		<transponder centre_frequency="578000000" bandwidth="0" system="1"/>
+		<transponder centre_frequency="586000000" bandwidth="0" system="1"/>
+		<transponder centre_frequency="618000000" bandwidth="0" system="1"/>
+		<transponder centre_frequency="666000000" bandwidth="0" system="1"/>
+		<transponder centre_frequency="474000000" bandwidth="0" system="1"/>
+		<transponder centre_frequency="522000000" bandwidth="0" system="1"/>
 	</terrestrial>
-	<terrestrial name="Breda (Europe DVB-T/T2)" flags="5" countrycode="NLD">
-		<transponder centre_frequency="306000000" bandwidth="0" system="0"/>
-		<transponder centre_frequency="546000000" bandwidth="0" system="0"/>
-		<transponder centre_frequency="786000000" bandwidth="0" system="0"/>
-		<transponder centre_frequency="554000000" bandwidth="0" system="0"/>
-		<transponder centre_frequency="562000000" bandwidth="0" system="0"/>
-		<transponder centre_frequency="570000000" bandwidth="0" system="0"/>
+	<terrestrial name="Zeeland (Europe DVB-T2)" flags="5" countrycode="NLD">
+		<transponder centre_frequency="538000000" bandwidth="0" system="1"/>
+		<transponder centre_frequency="562000000" bandwidth="0" system="1"/>
+		<transponder centre_frequency="570000000" bandwidth="0" system="1"/>
+		<transponder centre_frequency="586000000" bandwidth="0" system="1"/>
+		<transponder centre_frequency="618000000" bandwidth="0" system="1"/>
+		<transponder centre_frequency="690000000" bandwidth="0" system="1"/>
+		<transponder centre_frequency="474000000" bandwidth="0" system="1"/>
 	</terrestrial>
-	<terrestrial name="Delft ** (Europe DVB-T/T2)" flags="5" countrycode="NLD">
-		<transponder centre_frequency="306000000" bandwidth="0" system="0"/>
-		<transponder centre_frequency="722000000" bandwidth="0" system="0"/>
-		<transponder centre_frequency="698000000" bandwidth="0" system="0"/>
-		<transponder centre_frequency="762000000" bandwidth="0" system="0"/>
-		<transponder centre_frequency="498000000" bandwidth="0" system="0"/>
-		<transponder centre_frequency="522000000" bandwidth="0" system="0"/>
+	<terrestrial name="Noord Brabant (Europe DVB-T2)" flags="5" countrycode="NLD">
+		<transponder centre_frequency="474000000" bandwidth="0" system="1"/>
+		<transponder centre_frequency="482000000" bandwidth="0" system="1"/>
+		<transponder centre_frequency="514000000" bandwidth="0" system="1"/>
+		<transponder centre_frequency="530000000" bandwidth="0" system="1"/>
+		<transponder centre_frequency="546000000" bandwidth="0" system="1"/>
+		<transponder centre_frequency="554000000" bandwidth="0" system="1"/>
+		<transponder centre_frequency="578000000" bandwidth="0" system="1"/>
+		<transponder centre_frequency="618000000" bandwidth="0" system="1"/>
+		<transponder centre_frequency="642000000" bandwidth="0" system="1"/>
+		<transponder centre_frequency="570000000" bandwidth="0" system="1"/>
 	</terrestrial>
-	<terrestrial name="Den Bosch (Europe DVB-T/T2)" flags="5" countrycode="NLD">
-		<transponder centre_frequency="306000000" bandwidth="0" system="0"/>
-		<transponder centre_frequency="546000000" bandwidth="0" system="0"/>
-		<transponder centre_frequency="786000000" bandwidth="0" system="0"/>
-		<transponder centre_frequency="554000000" bandwidth="0" system="0"/>
-		<transponder centre_frequency="754000000" bandwidth="0" system="0"/>
-		<transponder centre_frequency="570000000" bandwidth="0" system="0"/>
-	</terrestrial>
-	<terrestrial name="Den Burg (Europe DVB-T/T2)" flags="5" countrycode="NLD">
-		<transponder centre_frequency="306000000" bandwidth="0" system="0"/>
-		<transponder centre_frequency="618000000" bandwidth="0" system="0"/>
-		<transponder centre_frequency="538000000" bandwidth="0" system="0"/>
-		<transponder centre_frequency="602000000" bandwidth="0" system="0"/>
-		<transponder centre_frequency="586000000" bandwidth="0" system="0"/>
-		<transponder centre_frequency="554000000" bandwidth="0" system="0"/>
-	</terrestrial>
-	<terrestrial name="Den Haag Beatrixlaan (Europe DVB-T/T2)" flags="5" countrycode="NLD">
-		<transponder centre_frequency="306000000" bandwidth="0" system="0"/>
-		<transponder centre_frequency="722000000" bandwidth="0" system="0"/>
-		<transponder centre_frequency="698000000" bandwidth="0" system="0"/>
-		<transponder centre_frequency="762000000" bandwidth="0" system="0"/>
-		<transponder centre_frequency="498000000" bandwidth="0" system="0"/>
-		<transponder centre_frequency="522000000" bandwidth="0" system="0"/>
-	</terrestrial>
-	<terrestrial name="Den Haag Kerkelanden (Europe DVB-T/T2)" flags="5" countrycode="NLD">
-		<transponder centre_frequency="306000000" bandwidth="0" system="0"/>
-		<transponder centre_frequency="722000000" bandwidth="0" system="0"/>
-		<transponder centre_frequency="698000000" bandwidth="0" system="0"/>
-		<transponder centre_frequency="762000000" bandwidth="0" system="0"/>
-		<transponder centre_frequency="498000000" bandwidth="0" system="0"/>
-		<transponder centre_frequency="522000000" bandwidth="0" system="0"/>
-	</terrestrial>
-	<terrestrial name="Deventer (Europe DVB-T/T2)" flags="5" countrycode="NLD">
-		<transponder centre_frequency="306000000" bandwidth="0" system="0"/>
-		<transponder centre_frequency="482000000" bandwidth="0" system="0"/>
-		<transponder centre_frequency="594000000" bandwidth="0" system="0"/>
-		<transponder centre_frequency="490000000" bandwidth="0" system="0"/>
-		<transponder centre_frequency="682000000" bandwidth="0" system="0"/>
-		<transponder centre_frequency="530000000" bandwidth="0" system="0"/>
-	</terrestrial>
-	<terrestrial name="Doetinchem (Europe DVB-T/T2)" flags="5" countrycode="NLD">
-		<transponder centre_frequency="306000000" bandwidth="0" system="0"/>
-		<transponder centre_frequency="642000000" bandwidth="0" system="0"/>
-		<transponder centre_frequency="594000000" bandwidth="0" system="0"/>
-		<transponder centre_frequency="770000000" bandwidth="0" system="0"/>
-		<transponder centre_frequency="730000000" bandwidth="0" system="0"/>
-		<transponder centre_frequency="530000000" bandwidth="0" system="0"/>
-	</terrestrial>
-	<terrestrial name="Eindhoven 1 (Europe DVB-T/T2)" flags="5" countrycode="NLD">
-		<transponder centre_frequency="306000000" bandwidth="0" system="0"/>
-		<transponder centre_frequency="546000000" bandwidth="0" system="0"/>
-		<transponder centre_frequency="786000000" bandwidth="0" system="0"/>
-		<transponder centre_frequency="554000000" bandwidth="0" system="0"/>
-		<transponder centre_frequency="754000000" bandwidth="0" system="0"/>
-		<transponder centre_frequency="570000000" bandwidth="0" system="0"/>
-	</terrestrial>
-	<terrestrial name="Eindhoven 2 (Europe DVB-T/T2)" flags="5" countrycode="NLD">
-		<transponder centre_frequency="306000000" bandwidth="0" system="0"/>
-		<transponder centre_frequency="546000000" bandwidth="0" system="0"/>
-		<transponder centre_frequency="786000000" bandwidth="0" system="0"/>
-		<transponder centre_frequency="554000000" bandwidth="0" system="0"/>
-		<transponder centre_frequency="754000000" bandwidth="0" system="0"/>
-		<transponder centre_frequency="570000000" bandwidth="0" system="0"/>
-	</terrestrial>
-	<terrestrial name="Enkhuizen (Europe DVB-T/T2)" flags="5" countrycode="NLD">
-		<transponder centre_frequency="306000000" bandwidth="0" system="0"/>
-		<transponder centre_frequency="618000000" bandwidth="0" system="0"/>
-		<transponder centre_frequency="666000000" bandwidth="0" system="0"/>
-		<transponder centre_frequency="578000000" bandwidth="0" system="0"/>
-		<transponder centre_frequency="586000000" bandwidth="0" system="0"/>
-		<transponder centre_frequency="658000000" bandwidth="0" system="0"/>
-	</terrestrial>
-	<terrestrial name="Enschede (Europe DVB-T/T2)" flags="5" countrycode="NLD">
-		<transponder centre_frequency="306000000" bandwidth="0" system="0"/>
-		<transponder centre_frequency="482000000" bandwidth="0" system="0"/>
-		<transponder centre_frequency="594000000" bandwidth="0" system="0"/>
-		<transponder centre_frequency="490000000" bandwidth="0" system="0"/>
-		<transponder centre_frequency="682000000" bandwidth="0" system="0"/>
-		<transponder centre_frequency="530000000" bandwidth="0" system="0"/>
-	</terrestrial>
-	<terrestrial name="Goes (Europe DVB-T/T2)" flags="5" countrycode="NLD">
-		<transponder centre_frequency="306000000" bandwidth="0" system="0"/>
-		<transponder centre_frequency="738000000" bandwidth="0" system="0"/>
-		<transponder centre_frequency="690000000" bandwidth="0" system="0"/>
-		<transponder centre_frequency="538000000" bandwidth="0" system="0"/>
-		<transponder centre_frequency="562000000" bandwidth="0" system="0"/>
-		<transponder centre_frequency="586000000" bandwidth="0" system="0"/>
-	</terrestrial>
-	<terrestrial name="Gorinchem ** (Europe DVB-T/T2)" flags="5" countrycode="NLD">
-		<transponder centre_frequency="306000000" bandwidth="0" system="0"/>
-		<transponder centre_frequency="474000000" bandwidth="0" system="0"/>
-		<transponder centre_frequency="698000000" bandwidth="0" system="0"/>
-		<transponder centre_frequency="762000000" bandwidth="0" system="0"/>
-		<transponder centre_frequency="498000000" bandwidth="0" system="0"/>
-		<transponder centre_frequency="522000000" bandwidth="0" system="0"/>
-	</terrestrial>
-	<terrestrial name="Gouda (Europe DVB-T/T2)" flags="5" countrycode="NLD">
-		<transponder centre_frequency="306000000" bandwidth="0" system="0"/>
-		<transponder centre_frequency="722000000" bandwidth="0" system="0"/>
-		<transponder centre_frequency="698000000" bandwidth="0" system="0"/>
-		<transponder centre_frequency="762000000" bandwidth="0" system="0"/>
-		<transponder centre_frequency="498000000" bandwidth="0" system="0"/>
-		<transponder centre_frequency="522000000" bandwidth="0" system="0"/>
-	</terrestrial>
-	<terrestrial name="Groningen (Europe DVB-T/T2)" flags="5" countrycode="NLD">
-		<transponder centre_frequency="306000000" bandwidth="0" system="0"/>
-		<transponder centre_frequency="626000000" bandwidth="0" system="0"/>
-		<transponder centre_frequency="674000000" bandwidth="0" system="0"/>
-		<transponder centre_frequency="546000000" bandwidth="0" system="0"/>
-		<transponder centre_frequency="738000000" bandwidth="0" system="0"/>
-		<transponder centre_frequency="570000000" bandwidth="0" system="0"/>
-		<transponder centre_frequency="506000000" bandwidth="0" system="0"/>
-	</terrestrial>
-	<terrestrial name="Haarlem (Europe DVB-T/T2)" flags="5" countrycode="NLD">
-		<transponder centre_frequency="306000000" bandwidth="0" system="0"/>
-		<transponder centre_frequency="618000000" bandwidth="0" system="0"/>
-		<transponder centre_frequency="698000000" bandwidth="0" system="0"/>
-		<transponder centre_frequency="762000000" bandwidth="0" system="0"/>
-		<transponder centre_frequency="498000000" bandwidth="0" system="0"/>
-		<transponder centre_frequency="522000000" bandwidth="0" system="0"/>
-	</terrestrial>
-	<terrestrial name="Heerlen (Europe DVB-T/T2)" flags="5" countrycode="NLD">
-		<transponder centre_frequency="306000000" bandwidth="0" system="0"/>
-		<transponder centre_frequency="738000000" bandwidth="0" system="0"/>
-		<transponder centre_frequency="578000000" bandwidth="0" system="0"/>
-		<transponder centre_frequency="498000000" bandwidth="0" system="0"/>
-		<transponder centre_frequency="714000000" bandwidth="0" system="0"/>
-		<transponder centre_frequency="522000000" bandwidth="0" system="0"/>
-	</terrestrial>
-	<terrestrial name="Helmond (Europe DVB-T/T2)" flags="5" countrycode="NLD">
-		<transponder centre_frequency="306000000" bandwidth="0" system="0"/>
-		<transponder centre_frequency="546000000" bandwidth="0" system="0"/>
-		<transponder centre_frequency="786000000" bandwidth="0" system="0"/>
-		<transponder centre_frequency="554000000" bandwidth="0" system="0"/>
-		<transponder centre_frequency="754000000" bandwidth="0" system="0"/>
-		<transponder centre_frequency="570000000" bandwidth="0" system="0"/>
-	</terrestrial>
-	<terrestrial name="Hengelo (Europe DVB-T/T2)" flags="5" countrycode="NLD">
-		<transponder centre_frequency="306000000" bandwidth="0" system="0"/>
-		<transponder centre_frequency="482000000" bandwidth="0" system="0"/>
-		<transponder centre_frequency="594000000" bandwidth="0" system="0"/>
-		<transponder centre_frequency="490000000" bandwidth="0" system="0"/>
-		<transponder centre_frequency="682000000" bandwidth="0" system="0"/>
-		<transponder centre_frequency="530000000" bandwidth="0" system="0"/>
-	</terrestrial>
-	<terrestrial name="Hilversum (Europe DVB-T/T2)" flags="5" countrycode="NLD">
-		<transponder centre_frequency="306000000" bandwidth="0" system="0"/>
-		<transponder centre_frequency="618000000" bandwidth="0" system="0"/>
-		<transponder centre_frequency="698000000" bandwidth="0" system="0"/>
-		<transponder centre_frequency="762000000" bandwidth="0" system="0"/>
-		<transponder centre_frequency="498000000" bandwidth="0" system="0"/>
-		<transponder centre_frequency="522000000" bandwidth="0" system="0"/>
-	</terrestrial>
-	<terrestrial name="Hoorn (Europe DVB-T/T2)" flags="5" countrycode="NLD">
-		<transponder centre_frequency="306000000" bandwidth="0" system="0"/>
-		<transponder centre_frequency="618000000" bandwidth="0" system="0"/>
-		<transponder centre_frequency="666000000" bandwidth="0" system="0"/>
-		<transponder centre_frequency="578000000" bandwidth="0" system="0"/>
-		<transponder centre_frequency="586000000" bandwidth="0" system="0"/>
-		<transponder centre_frequency="658000000" bandwidth="0" system="0"/>
-	</terrestrial>
-	<terrestrial name="IJsselstein (Lopik) (Europe DVB-T/T2)" flags="5" countrycode="NLD">
-		<transponder centre_frequency="306000000" bandwidth="0" system="0"/>
-		<transponder centre_frequency="706000000" bandwidth="0" system="0"/>
-		<transponder centre_frequency="698000000" bandwidth="0" system="0"/>
-		<transponder centre_frequency="762000000" bandwidth="0" system="0"/>
-		<transponder centre_frequency="498000000" bandwidth="0" system="0"/>
-		<transponder centre_frequency="522000000" bandwidth="0" system="0"/>
-	</terrestrial>
-	<terrestrial name="Krimpen aan den IJssel (Europe DVB-T/T2)" flags="5" countrycode="NLD">
-		<transponder centre_frequency="306000000" bandwidth="0" system="0"/>
-		<transponder centre_frequency="474000000" bandwidth="0" system="0"/>
-		<transponder centre_frequency="698000000" bandwidth="0" system="0"/>
-		<transponder centre_frequency="762000000" bandwidth="0" system="0"/>
-		<transponder centre_frequency="498000000" bandwidth="0" system="0"/>
-		<transponder centre_frequency="522000000" bandwidth="0" system="0"/>
-	</terrestrial>
-	<terrestrial name="Leeuwarden (Europe DVB-T/T2)" flags="5" countrycode="NLD">
-		<transponder centre_frequency="306000000" bandwidth="0" system="0"/>
-		<transponder centre_frequency="562000000" bandwidth="0" system="0"/>
-		<transponder centre_frequency="746000000" bandwidth="0" system="0"/>
-		<transponder centre_frequency="578000000" bandwidth="0" system="0"/>
-		<transponder centre_frequency="474000000" bandwidth="0" system="0"/>
-		<transponder centre_frequency="658000000" bandwidth="0" system="0"/>
-	</terrestrial>
-	<terrestrial name="Lelystad (Europe DVB-T/T2)" flags="5" countrycode="NLD">
-		<transponder centre_frequency="306000000" bandwidth="0" system="0"/>
-		<transponder centre_frequency="514000000" bandwidth="0" system="0"/>
-		<transponder centre_frequency="594000000" bandwidth="0" system="0"/>
-		<transponder centre_frequency="490000000" bandwidth="0" system="0"/>
-		<transponder centre_frequency="682000000" bandwidth="0" system="0"/>
-		<transponder centre_frequency="658000000" bandwidth="0" system="0"/>
-	</terrestrial>
-	<terrestrial name="Loon op Zand (Europe DVB-T/T2)" flags="5" countrycode="NLD">
-		<transponder centre_frequency="306000000" bandwidth="0" system="0"/>
-		<transponder centre_frequency="546000000" bandwidth="0" system="0"/>
-		<transponder centre_frequency="786000000" bandwidth="0" system="0"/>
-		<transponder centre_frequency="554000000" bandwidth="0" system="0"/>
-		<transponder centre_frequency="754000000" bandwidth="0" system="0"/>
-		<transponder centre_frequency="570000000" bandwidth="0" system="0"/>
-	</terrestrial>
-	<terrestrial name="Maarssen (Europe DVB-T/T2)" flags="5" countrycode="NLD">
-		<transponder centre_frequency="306000000" bandwidth="0" system="0"/>
-		<transponder centre_frequency="706000000" bandwidth="0" system="0"/>
-		<transponder centre_frequency="698000000" bandwidth="0" system="0"/>
-		<transponder centre_frequency="762000000" bandwidth="0" system="0"/>
-		<transponder centre_frequency="498000000" bandwidth="0" system="0"/>
-		<transponder centre_frequency="522000000" bandwidth="0" system="0"/>
-	</terrestrial>
-	<terrestrial name="Maastricht (Europe DVB-T/T2)" flags="5" countrycode="NLD">
-		<transponder centre_frequency="306000000" bandwidth="0" system="0"/>
-		<transponder centre_frequency="738000000" bandwidth="0" system="0"/>
-		<transponder centre_frequency="578000000" bandwidth="0" system="0"/>
-		<transponder centre_frequency="498000000" bandwidth="0" system="0"/>
-		<transponder centre_frequency="714000000" bandwidth="0" system="0"/>
-		<transponder centre_frequency="522000000" bandwidth="0" system="0"/>
-	</terrestrial>
-	<terrestrial name="Nijmegen (Europe DVB-T/T2)" flags="5" countrycode="NLD">
-		<transponder centre_frequency="306000000" bandwidth="0" system="0"/>
-		<transponder centre_frequency="642000000" bandwidth="0" system="0"/>
-		<transponder centre_frequency="786000000" bandwidth="0" system="0"/>
-		<transponder centre_frequency="554000000" bandwidth="0" system="0"/>
-		<transponder centre_frequency="754000000" bandwidth="0" system="0"/>
-		<transponder centre_frequency="570000000" bandwidth="0" system="0"/>
-	</terrestrial>
-	<terrestrial name="Oegstgeest (Europe DVB-T/T2)" flags="5" countrycode="NLD">
-		<transponder centre_frequency="306000000" bandwidth="0" system="0"/>
-		<transponder centre_frequency="722000000" bandwidth="0" system="0"/>
-		<transponder centre_frequency="698000000" bandwidth="0" system="0"/>
-		<transponder centre_frequency="762000000" bandwidth="0" system="0"/>
-		<transponder centre_frequency="498000000" bandwidth="0" system="0"/>
-		<transponder centre_frequency="522000000" bandwidth="0" system="0"/>
-	</terrestrial>
-	<terrestrial name="Oss (Noord-Brabant) (Europe DVB-T/T2)" flags="5" countrycode="NLD">
-		<transponder centre_frequency="306000000" bandwidth="0" system="0"/>
-		<transponder centre_frequency="546000000" bandwidth="0" system="0"/>
-		<transponder centre_frequency="786000000" bandwidth="0" system="0"/>
-		<transponder centre_frequency="554000000" bandwidth="0" system="0"/>
-		<transponder centre_frequency="754000000" bandwidth="0" system="0"/>
-		<transponder centre_frequency="570000000" bandwidth="0" system="0"/>
-	</terrestrial>
-	<terrestrial name="Oss (gelderland) (Europe DVB-T/T2)" flags="5" countrycode="NLD">
-		<transponder centre_frequency="306000000" bandwidth="0" system="0"/>
-		<transponder centre_frequency="642000000" bandwidth="0" system="0"/>
-		<transponder centre_frequency="786000000" bandwidth="0" system="0"/>
-		<transponder centre_frequency="554000000" bandwidth="0" system="0"/>
-		<transponder centre_frequency="754000000" bandwidth="0" system="0"/>
-		<transponder centre_frequency="570000000" bandwidth="0" system="0"/>
-	</terrestrial>
-	<terrestrial name="Roermond (Europe DVB-T/T2)" flags="5" countrycode="NLD">
-		<transponder centre_frequency="306000000" bandwidth="0" system="0"/>
-		<transponder centre_frequency="738000000" bandwidth="0" system="0"/>
-		<transponder centre_frequency="578000000" bandwidth="0" system="0"/>
-		<transponder centre_frequency="498000000" bandwidth="0" system="0"/>
-		<transponder centre_frequency="714000000" bandwidth="0" system="0"/>
-		<transponder centre_frequency="522000000" bandwidth="0" system="0"/>
-	</terrestrial>
-	<terrestrial name="Roosendaal (Europe DVB-T/T2)" flags="5" countrycode="NLD">
-		<transponder centre_frequency="306000000" bandwidth="0" system="0"/>
-		<transponder centre_frequency="546000000" bandwidth="0" system="0"/>
-		<transponder centre_frequency="690000000" bandwidth="0" system="0"/>
-		<transponder centre_frequency="538000000" bandwidth="0" system="0"/>
-		<transponder centre_frequency="562000000" bandwidth="0" system="0"/>
-		<transponder centre_frequency="586000000" bandwidth="0" system="0"/>
-	</terrestrial>
-	<terrestrial name="Rotterdam Maastoren (Europe DVB-T/T2)" flags="5" countrycode="NLD">
-		<transponder centre_frequency="306000000" bandwidth="0" system="0"/>
-		<transponder centre_frequency="474000000" bandwidth="0" system="0"/>
-		<transponder centre_frequency="698000000" bandwidth="0" system="0"/>
-		<transponder centre_frequency="762000000" bandwidth="0" system="0"/>
-		<transponder centre_frequency="498000000" bandwidth="0" system="0"/>
-		<transponder centre_frequency="522000000" bandwidth="0" system="0"/>
-	</terrestrial>
-	<terrestrial name="Rotterdam Waalhaven (Europe DVB-T/T2)" flags="5" countrycode="NLD">
-		<transponder centre_frequency="306000000" bandwidth="0" system="0"/>
-		<transponder centre_frequency="474000000" bandwidth="0" system="0"/>
-		<transponder centre_frequency="698000000" bandwidth="0" system="0"/>
-		<transponder centre_frequency="762000000" bandwidth="0" system="0"/>
-		<transponder centre_frequency="498000000" bandwidth="0" system="0"/>
-		<transponder centre_frequency="522000000" bandwidth="0" system="0"/>
-	</terrestrial>
-	<terrestrial name="Sittard (Europe DVB-T/T2)" flags="5" countrycode="NLD">
-		<transponder centre_frequency="306000000" bandwidth="0" system="0"/>
-		<transponder centre_frequency="738000000" bandwidth="0" system="0"/>
-		<transponder centre_frequency="578000000" bandwidth="0" system="0"/>
-		<transponder centre_frequency="498000000" bandwidth="0" system="0"/>
-		<transponder centre_frequency="714000000" bandwidth="0" system="0"/>
-		<transponder centre_frequency="522000000" bandwidth="0" system="0"/>
-	</terrestrial>
-	<terrestrial name="Sliedrecht (Europe DVB-T/T2)" flags="5" countrycode="NLD">
-		<transponder centre_frequency="306000000" bandwidth="0" system="0"/>
-		<transponder centre_frequency="474000000" bandwidth="0" system="0"/>
-		<transponder centre_frequency="698000000" bandwidth="0" system="0"/>
-		<transponder centre_frequency="762000000" bandwidth="0" system="0"/>
-		<transponder centre_frequency="498000000" bandwidth="0" system="0"/>
-		<transponder centre_frequency="522000000" bandwidth="0" system="0"/>
-	</terrestrial>
-	<terrestrial name="Smilde (Europe DVB-T/T2)" flags="5" countrycode="NLD">
-		<transponder centre_frequency="306000000" bandwidth="0" system="0"/>
-		<transponder centre_frequency="786000000" bandwidth="0" system="0"/>
-		<transponder centre_frequency="546000000" bandwidth="0" system="0"/>
-		<transponder centre_frequency="738000000" bandwidth="0" system="0"/>
-		<transponder centre_frequency="570000000" bandwidth="0" system="0"/>
-		<transponder centre_frequency="506000000" bandwidth="0" system="0"/>
-	</terrestrial>
-	<terrestrial name="Utrecht (Europe DVB-T/T2)" flags="5" countrycode="NLD">
-		<transponder centre_frequency="306000000" bandwidth="0" system="0"/>
-		<transponder centre_frequency="706000000" bandwidth="0" system="0"/>
-		<transponder centre_frequency="698000000" bandwidth="0" system="0"/>
-		<transponder centre_frequency="762000000" bandwidth="0" system="0"/>
-		<transponder centre_frequency="498000000" bandwidth="0" system="0"/>
-		<transponder centre_frequency="522000000" bandwidth="0" system="0"/>
-	</terrestrial>
-	<terrestrial name="Veenendaal (Gelderland) (Europe DVB-T/T2)" flags="5" countrycode="NLD">
-		<transponder centre_frequency="306000000" bandwidth="0" system="0"/>
-		<transponder centre_frequency="642000000" bandwidth="0" system="0"/>
-		<transponder centre_frequency="594000000" bandwidth="0" system="0"/>
-		<transponder centre_frequency="770000000" bandwidth="0" system="0"/>
-		<transponder centre_frequency="730000000" bandwidth="0" system="0"/>
-		<transponder centre_frequency="530000000" bandwidth="0" system="0"/>
-	</terrestrial>
-	<terrestrial name="Veenendaal (Utrecht) (Europe DVB-T/T2)" flags="5" countrycode="NLD">
-		<transponder centre_frequency="306000000" bandwidth="0" system="0"/>
-		<transponder centre_frequency="706000000" bandwidth="0" system="0"/>
-		<transponder centre_frequency="594000000" bandwidth="0" system="0"/>
-		<transponder centre_frequency="770000000" bandwidth="0" system="0"/>
-		<transponder centre_frequency="730000000" bandwidth="0" system="0"/>
-		<transponder centre_frequency="530000000" bandwidth="0" system="0"/>
-	</terrestrial>
-	<terrestrial name="Venlo (Europe DVB-T/T2)" flags="5" countrycode="NLD">
-		<transponder centre_frequency="306000000" bandwidth="0" system="0"/>
-		<transponder centre_frequency="738000000" bandwidth="0" system="0"/>
-		<transponder centre_frequency="578000000" bandwidth="0" system="0"/>
-		<transponder centre_frequency="554000000" bandwidth="0" system="0"/>
-		<transponder centre_frequency="754000000" bandwidth="0" system="0"/>
-		<transponder centre_frequency="522000000" bandwidth="0" system="0"/>
-	</terrestrial>
-	<terrestrial name="Vlaardingen (Europe DVB-T/T2)" flags="5" countrycode="NLD">
-		<transponder centre_frequency="306000000" bandwidth="0" system="0"/>
-		<transponder centre_frequency="474000000" bandwidth="0" system="0"/>
-		<transponder centre_frequency="698000000" bandwidth="0" system="0"/>
-		<transponder centre_frequency="762000000" bandwidth="0" system="0"/>
-		<transponder centre_frequency="498000000" bandwidth="0" system="0"/>
-		<transponder centre_frequency="522000000" bandwidth="0" system="0"/>
-	</terrestrial>
-	<terrestrial name="Wormer (Europe DVB-T/T2)" flags="5" countrycode="NLD">
-		<transponder centre_frequency="306000000" bandwidth="0" system="0"/>
-		<transponder centre_frequency="618000000" bandwidth="0" system="0"/>
-		<transponder centre_frequency="698000000" bandwidth="0" system="0"/>
-		<transponder centre_frequency="762000000" bandwidth="0" system="0"/>
-		<transponder centre_frequency="498000000" bandwidth="0" system="0"/>
-		<transponder centre_frequency="522000000" bandwidth="0" system="0"/>
-	</terrestrial>
-	<terrestrial name="Zoetermeer (Europe DVB-T/T2)" flags="5" countrycode="NLD">
-		<transponder centre_frequency="306000000" bandwidth="0" system="0"/>
-		<transponder centre_frequency="722000000" bandwidth="0" system="0"/>
-		<transponder centre_frequency="698000000" bandwidth="0" system="0"/>
-		<transponder centre_frequency="762000000" bandwidth="0" system="0"/>
-		<transponder centre_frequency="498000000" bandwidth="0" system="0"/>
-		<transponder centre_frequency="522000000" bandwidth="0" system="0"/>
-	</terrestrial>
-	<terrestrial name="Zwolle (Europe DVB-T/T2)" flags="5" countrycode="NLD">
-		<transponder centre_frequency="306000000" bandwidth="0" system="0"/>
-		<transponder centre_frequency="482000000" bandwidth="0" system="0"/>
-		<transponder centre_frequency="594000000" bandwidth="0" system="0"/>
-		<transponder centre_frequency="490000000" bandwidth="0" system="0"/>
-		<transponder centre_frequency="682000000" bandwidth="0" system="0"/>
-		<transponder centre_frequency="530000000" bandwidth="0" system="0"/>
+	<terrestrial name="Limburg (Europe DVB-T2)" flags="5" countrycode="NLD">
+		<transponder centre_frequency="474000000" bandwidth="0" system="1"/>
+		<transponder centre_frequency="514000000" bandwidth="0" system="1"/>
+		<transponder centre_frequency="530000000" bandwidth="0" system="1"/>
+		<transponder centre_frequency="546000000" bandwidth="0" system="1"/>
+		<transponder centre_frequency="554000000" bandwidth="0" system="1"/>
+		<transponder centre_frequency="618000000" bandwidth="0" system="1"/>
+		<transponder centre_frequency="498000000" bandwidth="0" system="1"/>
+		<transponder centre_frequency="522000000" bandwidth="0" system="1"/>
+		<transponder centre_frequency="570000000" bandwidth="0" system="1"/>
 	</terrestrial>
 	<terrestrial name="All Regions, New Zealand, (Europe DVB-T/T2)" countrycode="NZL">
 		<!--


### PR DESCRIPTION
Since all frequencies in The Netherlands are DVB-T2 now for a long time I changed the parameters accordingly.
Deleted the not used frequencies except channel 55 which could still be used besides the LTE frequencies (but probably never will be used).

Furthermore a regional division (with some overlap) is more logical than listing all transmitters apart.