### PR TITLE
2022 changes on Polish DVB-T/T2 (#108)

### DIFF
--- a/xml/terrestrial.xml
+++ b/xml/terrestrial.xml
@@ -2770,292 +2770,276 @@
 		<transponder centre_frequency="698000000" bandwidth="0" constellation="3" /> <!-- Ch 49 -->
 	</terrestrial>
 	<terrestrial name="Polska (Europe DVB-T/T2)" flags="5" countrycode="POL">
-		<transponder centre_frequency="177500000" bandwidth="1" constellation="3" system="0" /> <!-- Ch 05 -->
-		<transponder centre_frequency="184500000" bandwidth="1" constellation="3" system="0" /> <!-- Ch 06 -->
-		<transponder centre_frequency="191500000" bandwidth="1" constellation="3" system="0" /> <!-- Ch 07 -->
-		<transponder centre_frequency="198500000" bandwidth="1" constellation="3" system="0" /> <!-- Ch 08 -->
-		<transponder centre_frequency="205500000" bandwidth="1" constellation="3" system="0" /> <!-- Ch 09 -->
-		<transponder centre_frequency="212500000" bandwidth="1" constellation="3" system="0" /> <!-- Ch 10 -->
-		<transponder centre_frequency="219500000" bandwidth="1" constellation="3" system="0" /> <!-- Ch 11 -->
-		<transponder centre_frequency="226500000" bandwidth="1" constellation="3" system="0" /> <!-- Ch 12 -->
-		<transponder centre_frequency="474000000" bandwidth="0" constellation="3" system="0" /> <!-- Ch 21 -->
-		<transponder centre_frequency="482000000" bandwidth="0" constellation="3" system="0" /> <!-- Ch 22 -->
-		<transponder centre_frequency="490000000" bandwidth="0" constellation="3" system="0" /> <!-- Ch 23 -->
-		<transponder centre_frequency="498000000" bandwidth="0" constellation="3" system="0" /> <!-- Ch 24 -->
-		<transponder centre_frequency="506000000" bandwidth="0" constellation="3" system="0" /> <!-- Ch 25 -->
-		<transponder centre_frequency="514000000" bandwidth="0" constellation="3" system="0" /> <!-- Ch 26 -->
-		<transponder centre_frequency="522000000" bandwidth="0" constellation="3" system="0" /> <!-- Ch 27 -->
-		<transponder centre_frequency="530000000" bandwidth="0" constellation="3" system="0" /> <!-- Ch 28 -->
-		<transponder centre_frequency="538000000" bandwidth="0" constellation="3" system="0" /> <!-- Ch 29 -->
-		<transponder centre_frequency="546000000" bandwidth="0" constellation="3" system="0" /> <!-- Ch 30 -->
-		<transponder centre_frequency="554000000" bandwidth="0" constellation="3" system="0" /> <!-- Ch 31 -->
-		<transponder centre_frequency="562000000" bandwidth="0" constellation="3" system="0" /> <!-- Ch 32 -->
-		<transponder centre_frequency="570000000" bandwidth="0" constellation="3" system="0" /> <!-- Ch 33 -->
-		<transponder centre_frequency="578000000" bandwidth="0" constellation="3" system="0" /> <!-- Ch 34 -->
-		<transponder centre_frequency="586000000" bandwidth="0" constellation="3" system="0" /> <!-- Ch 35 -->
-		<transponder centre_frequency="594000000" bandwidth="0" constellation="3" system="0" /> <!-- Ch 36 -->
-		<transponder centre_frequency="602000000" bandwidth="0" constellation="3" system="0" /> <!-- Ch 37 -->
-		<transponder centre_frequency="610000000" bandwidth="0" constellation="3" system="0" /> <!-- Ch 38 -->
-		<transponder centre_frequency="618000000" bandwidth="0" constellation="3" system="0" /> <!-- Ch 39 -->
-		<transponder centre_frequency="626000000" bandwidth="0" constellation="3" system="0" /> <!-- Ch 40 -->
-		<transponder centre_frequency="634000000" bandwidth="0" constellation="3" system="0" /> <!-- Ch 41 -->
-		<transponder centre_frequency="642000000" bandwidth="0" constellation="3" system="0" /> <!-- Ch 42 -->
-		<transponder centre_frequency="650000000" bandwidth="0" constellation="3" system="0" /> <!-- Ch 43 -->
-		<transponder centre_frequency="658000000" bandwidth="0" constellation="3" system="0" /> <!-- Ch 44 -->
-		<transponder centre_frequency="666000000" bandwidth="0" constellation="3" system="0" /> <!-- Ch 45 -->
-		<transponder centre_frequency="674000000" bandwidth="0" constellation="3" system="0" /> <!-- Ch 46 -->
-		<transponder centre_frequency="682000000" bandwidth="0" constellation="3" system="0" /> <!-- Ch 47 -->
-		<transponder centre_frequency="690000000" bandwidth="0" constellation="3" system="0" /> <!-- Ch 48 -->
-		<transponder centre_frequency="698000000" bandwidth="0" constellation="3" system="0" /> <!-- Ch 49 -->
-		<transponder centre_frequency="706000000" bandwidth="0" constellation="3" system="0" /> <!-- Ch 50 -->
-		<transponder centre_frequency="714000000" bandwidth="0" constellation="3" system="0" /> <!-- Ch 51 -->
-		<transponder centre_frequency="722000000" bandwidth="0" constellation="3" system="0" /> <!-- Ch 52 -->
-		<transponder centre_frequency="730000000" bandwidth="0" constellation="3" system="0" /> <!-- Ch 53 -->
-		<transponder centre_frequency="738000000" bandwidth="0" constellation="3" system="0" /> <!-- Ch 54 -->
-		<transponder centre_frequency="746000000" bandwidth="0" constellation="3" system="0" /> <!-- Ch 55 -->
-		<transponder centre_frequency="754000000" bandwidth="0" constellation="3" system="0" /> <!-- Ch 56 -->
-		<transponder centre_frequency="762000000" bandwidth="0" constellation="3" system="0" /> <!-- Ch 57 -->
-		<transponder centre_frequency="770000000" bandwidth="0" constellation="3" system="0" /> <!-- Ch 58 -->
-		<transponder centre_frequency="778000000" bandwidth="0" constellation="3" system="0" /> <!-- Ch 59 -->
-		<transponder centre_frequency="786000000" bandwidth="0" constellation="3" system="0" /> <!-- Ch 60 -->
+		<transponder centre_frequency="177500000" bandwidth="1" constellation="3" /> <!-- Ch 05 -->
+		<transponder centre_frequency="184500000" bandwidth="1" constellation="3" /> <!-- Ch 06 -->
+		<transponder centre_frequency="191500000" bandwidth="1" constellation="3" /> <!-- Ch 07 -->
+		<transponder centre_frequency="198500000" bandwidth="1" constellation="3" /> <!-- Ch 08 -->
+		<transponder centre_frequency="205500000" bandwidth="1" constellation="3" /> <!-- Ch 09 -->
+		<transponder centre_frequency="212500000" bandwidth="1" constellation="3" /> <!-- Ch 10 -->
+		<transponder centre_frequency="219500000" bandwidth="1" constellation="3" /> <!-- Ch 11 -->
+		<transponder centre_frequency="226500000" bandwidth="1" constellation="3" /> <!-- Ch 12 -->
+		<transponder centre_frequency="474000000" bandwidth="0" constellation="3" /> <!-- Ch 21 -->
+		<transponder centre_frequency="482000000" bandwidth="0" constellation="3" /> <!-- Ch 22 -->
+		<transponder centre_frequency="490000000" bandwidth="0" constellation="3" /> <!-- Ch 23 -->
+		<transponder centre_frequency="498000000" bandwidth="0" constellation="3" /> <!-- Ch 24 -->
+		<transponder centre_frequency="506000000" bandwidth="0" constellation="3" /> <!-- Ch 25 -->
+		<transponder centre_frequency="514000000" bandwidth="0" constellation="3" /> <!-- Ch 26 -->
+		<transponder centre_frequency="522000000" bandwidth="0" constellation="3" /> <!-- Ch 27 -->
+		<transponder centre_frequency="530000000" bandwidth="0" constellation="3" /> <!-- Ch 28 -->
+		<transponder centre_frequency="538000000" bandwidth="0" constellation="3" /> <!-- Ch 29 -->
+		<transponder centre_frequency="546000000" bandwidth="0" constellation="3" /> <!-- Ch 30 -->
+		<transponder centre_frequency="554000000" bandwidth="0" constellation="3" /> <!-- Ch 31 -->
+		<transponder centre_frequency="562000000" bandwidth="0" constellation="3" /> <!-- Ch 32 -->
+		<transponder centre_frequency="570000000" bandwidth="0" constellation="3" /> <!-- Ch 33 -->
+		<transponder centre_frequency="578000000" bandwidth="0" constellation="3" /> <!-- Ch 34 -->
+		<transponder centre_frequency="586000000" bandwidth="0" constellation="3" /> <!-- Ch 35 -->
+		<transponder centre_frequency="594000000" bandwidth="0" constellation="3" /> <!-- Ch 36 -->
+		<transponder centre_frequency="602000000" bandwidth="0" constellation="3" /> <!-- Ch 37 -->
+		<transponder centre_frequency="610000000" bandwidth="0" constellation="3" /> <!-- Ch 38 -->
+		<transponder centre_frequency="618000000" bandwidth="0" constellation="3" /> <!-- Ch 39 -->
+		<transponder centre_frequency="626000000" bandwidth="0" constellation="3" /> <!-- Ch 40 -->
+		<transponder centre_frequency="634000000" bandwidth="0" constellation="3" /> <!-- Ch 41 -->
+		<transponder centre_frequency="642000000" bandwidth="0" constellation="3" /> <!-- Ch 42 -->
+		<transponder centre_frequency="650000000" bandwidth="0" constellation="3" /> <!-- Ch 43 -->
+		<transponder centre_frequency="658000000" bandwidth="0" constellation="3" /> <!-- Ch 44 -->
+		<transponder centre_frequency="666000000" bandwidth="0" constellation="3" /> <!-- Ch 45 -->
+		<transponder centre_frequency="674000000" bandwidth="0" constellation="3" /> <!-- Ch 46 -->
+		<transponder centre_frequency="682000000" bandwidth="0" constellation="3" /> <!-- Ch 47 -->
+		<transponder centre_frequency="690000000" bandwidth="0" constellation="3" /> <!-- Ch 48 -->
 	</terrestrial>
 	<terrestrial name="Polska, Bialystok (Europe DVB-T/T2)" flags="5" countrycode="POL">
-		<transponder centre_frequency="198500000" bandwidth="1" constellation="3" system="0" /> <!-- Ch 08 -->
-		<transponder centre_frequency="482000000" bandwidth="0" constellation="3" system="0" /> <!-- Ch 22 -->
-		<transponder centre_frequency="586000000" bandwidth="0" constellation="3" system="1" /> <!-- Ch 35 DVB-T2 HEVC test emission -->
-		<transponder centre_frequency="674000000" bandwidth="0" constellation="3" system="0" /> <!-- Ch 46 -->
-		<transponder centre_frequency="698000000" bandwidth="0" constellation="3" system="0" /> <!-- Ch 49 -->
+		<transponder centre_frequency="198500000" bandwidth="1" constellation="3" system="0" /> <!-- Ch 08 MUX-8 DVB-T -->
+		<transponder centre_frequency="482000000" bandwidth="0" constellation="3" system="1" /> <!-- Ch 22 -->
+		<transponder centre_frequency="586000000" bandwidth="0" constellation="3" system="0" /> <!-- Ch 35 MUX-3 DVB-T -->
+		<transponder centre_frequency="610000000" bandwidth="0" constellation="3" system="1" /> <!-- Ch 38 -->
+		<transponder centre_frequency="650000000" bandwidth="0" constellation="3" system="1" /> <!-- Ch 43 -->	
 	</terrestrial>
 	<terrestrial name="Polska, Bydgoszcz (Europe DVB-T/T2)" flags="5" countrycode="POL">
-		<transponder centre_frequency="198500000" bandwidth="1" constellation="3" system="0" /> <!-- Ch 08 -->
-		<transponder centre_frequency="562000000" bandwidth="0" constellation="3" system="0" /> <!-- Ch 32 -->
-		<transponder centre_frequency="594000000" bandwidth="0" constellation="3" system="0" /> <!-- Ch 36 -->
-		<transponder centre_frequency="626000000" bandwidth="0" constellation="3" system="1" /> <!-- Ch 40 DVB-T2 HEVC test emission -->
-		<transponder centre_frequency="634000000" bandwidth="0" constellation="3" system="0" /> <!-- Ch 41 -->
+		<transponder centre_frequency="198500000" bandwidth="1" constellation="3" system="0" /> <!-- Ch 08 MUX-8 DVB-T -->
+		<transponder centre_frequency="546000000" bandwidth="0" constellation="3" system="1" /> <!-- Ch 30 -->
+		<transponder centre_frequency="562000000" bandwidth="0" constellation="3" system="1" /> <!-- Ch 32 -->
+		<transponder centre_frequency="594000000" bandwidth="0" constellation="3" system="0" /> <!-- Ch 36 MUX-3 DVB-T -->
+		<transponder centre_frequency="634000000" bandwidth="0" constellation="3" system="1" /> <!-- Ch 41 -->
 	</terrestrial>
 	<terrestrial name="Polska, Ciechanow (Europe DVB-T/T2)" flags="5" countrycode="POL">
-		<transponder centre_frequency="226500000" bandwidth="1" constellation="3" system="0" /> <!-- Ch 12 -->
-		<transponder centre_frequency="506000000" bandwidth="0" constellation="3" system="0" /> <!-- Ch 25 -->
-		<transponder centre_frequency="618000000" bandwidth="0" constellation="3" system="0" /> <!-- Ch 39 -->
-		<transponder centre_frequency="658000000" bandwidth="0" constellation="3" system="1" /> <!-- Ch 44 DVB-T2 HEVC test emission -->
-		<transponder centre_frequency="762000000" bandwidth="0" constellation="3" system="0" /> <!-- Ch 57 -->
+		<transponder centre_frequency="226500000" bandwidth="1" constellation="3" system="0" /> <!-- Ch 12 MUX-8 DVB-T -->
+		<transponder centre_frequency="506000000" bandwidth="0" constellation="3" system="1" /> <!-- Ch 25 -->
+		<transponder centre_frequency="546000000" bandwidth="0" constellation="3" system="1" /> <!-- Ch 30 -->
+		<transponder centre_frequency="642000000" bandwidth="0" constellation="3" system="0" /> <!-- Ch 42 MUX-3 DVB-T -->
+		<transponder centre_frequency="658000000" bandwidth="0" constellation="3" system="1" /> <!-- Ch 44 -->
 	</terrestrial>
 	<terrestrial name="Polska, Czestochowa (Europe DVB-T/T2)" flags="5" countrycode="POL">
-		<transponder centre_frequency="205500000" bandwidth="1" constellation="3" system="0" /> <!-- Ch 09 -->
-		<transponder centre_frequency="522000000" bandwidth="0" constellation="3" system="1" /> <!-- Ch 27 DVB-T2 HEVC test emission -->
-		<transponder centre_frequency="586000000" bandwidth="0" constellation="3" system="0" /> <!-- Ch 35 -->
-		<transponder centre_frequency="618000000" bandwidth="0" constellation="3" system="0" /> <!-- Ch 39 -->
-		<transponder centre_frequency="634000000" bandwidth="0" constellation="3" system="0" /> <!-- Ch 41 -->
+		<transponder centre_frequency="205500000" bandwidth="1" constellation="3" system="0" /> <!-- Ch 09 MUX-8 DVB-T -->
+		<transponder centre_frequency="538000000" bandwidth="0" constellation="3" system="1" /> <!-- Ch 29 -->
+		<transponder centre_frequency="562000000" bandwidth="0" constellation="3" system="1" /> <!-- Ch 32 -->
+		<transponder centre_frequency="618000000" bandwidth="0" constellation="3" system="1" /> <!-- Ch 39 -->
+		<transponder centre_frequency="634000000" bandwidth="0" constellation="3" system="0" /> <!-- Ch 41 MUX-3 DVB-T -->
 	</terrestrial>
 	<terrestrial name="Polska, Elblag (Europe DVB-T/T2)" flags="5" countrycode="POL">
-		<transponder centre_frequency="184500000" bandwidth="1" constellation="3" system="0" /> <!-- Ch 06 -->
-		<transponder centre_frequency="474000000" bandwidth="0" constellation="3" system="0" /> <!-- Ch 21 -->
-		<transponder centre_frequency="514000000" bandwidth="0" constellation="3" system="0" /> <!-- Ch 26 -->
-		<transponder centre_frequency="522000000" bandwidth="0" constellation="3" system="0" /> <!-- Ch 27 -->
-		<transponder centre_frequency="658000000" bandwidth="0" constellation="3" system="1" /> <!-- Ch 44 DVB-T2 HEVC test emission -->
+		<transponder centre_frequency="184500000" bandwidth="1" constellation="3" system="0" /> <!-- Ch 06 MUX-8 DVB-T -->
+		<transponder centre_frequency="490000000" bandwidth="0" constellation="3" system="0" /> <!-- Ch 23 MUX-3 DVB-T -->
+		<transponder centre_frequency="514000000" bandwidth="0" constellation="3" system="1" /> <!-- Ch 26 -->
+		<transponder centre_frequency="522000000" bandwidth="0" constellation="3" system="1" /> <!-- Ch 27 -->
+		<transponder centre_frequency="658000000" bandwidth="0" constellation="3" system="1" /> <!-- Ch 44 -->
 	</terrestrial>
 	<terrestrial name="Polska, Gdansk (Europe DVB-T/T2)" flags="5" countrycode="POL">
-		<transponder centre_frequency="184500000" bandwidth="1" constellation="3" system="0" /> <!-- Ch 06 -->
-		<transponder centre_frequency="482000000" bandwidth="0" constellation="3" system="0" /> <!-- Ch 22 -->
-		<transponder centre_frequency="506000000" bandwidth="0" constellation="3" system="0" /> <!-- Ch 25 -->
-		<transponder centre_frequency="586000000" bandwidth="0" constellation="3" system="0" /> <!-- Ch 35 -->
-		<transponder centre_frequency="602000000" bandwidth="0" constellation="3" system="0" /> <!-- Ch 37 -->
-		<transponder centre_frequency="650000000" bandwidth="0" constellation="3" system="1" /> <!-- Ch 43 DVB-T2 HEVC test emission -->
-		<transponder centre_frequency="658000000" bandwidth="0" constellation="3" system="1" /> <!-- Ch 44 DVB-T2 HEVC test emission -->
+		<transponder centre_frequency="184500000" bandwidth="1" constellation="3" system="0" /> <!-- Ch 06 MUX-8 DVB-T -->
+		<transponder centre_frequency="482000000" bandwidth="0" constellation="3" system="0" /> <!-- Ch 22 MUX-3 DVB-T -->
+		<transponder centre_frequency="506000000" bandwidth="0" constellation="3" system="1" /> <!-- Ch 25 -->
+		<transponder centre_frequency="554000000" bandwidth="0" constellation="3" system="1" /> <!-- Ch 31 -->
+		<transponder centre_frequency="602000000" bandwidth="0" constellation="3" system="1" /> <!-- Ch 37 -->
+		<transponder centre_frequency="618000000" bandwidth="0" constellation="3" system="1" /> <!-- Ch 39 -->
+		<transponder centre_frequency="658000000" bandwidth="0" constellation="3" system="1" /> <!-- Ch 44 -->
 	</terrestrial>
 	<terrestrial name="Polska, Gizycko (Europe DVB-T/T2)" flags="5" countrycode="POL">
-		<transponder centre_frequency="191500000" bandwidth="1" constellation="3" system="0" /> <!-- Ch 07 -->
-		<transponder centre_frequency="498000000" bandwidth="0" constellation="3" system="1" /> <!-- Ch 24 DVB-T2 HEVC test emission -->
-		<transponder centre_frequency="650000000" bandwidth="0" constellation="3" system="0" /> <!-- Ch 43 -->
-		<transponder centre_frequency="690000000" bandwidth="0" constellation="3" system="0" /> <!-- Ch 48 -->
-		<transponder centre_frequency="706000000" bandwidth="0" constellation="3" system="0" /> <!-- Ch 50 -->
+		<transponder centre_frequency="191500000" bandwidth="1" constellation="3" system="0" /> <!-- Ch 07 MUX-8 DVB-T -->
+		<transponder centre_frequency="482000000" bandwidth="0" constellation="3" system="1" /> <!-- Ch 22 -->
+		<transponder centre_frequency="514000000" bandwidth="0" constellation="3" system="1" /> <!-- Ch 26 -->
+		<transponder centre_frequency="594000000" bandwidth="0" constellation="3" system="1" /> <!-- Ch 36 -->
+		<transponder centre_frequency="690000000" bandwidth="0" constellation="3" system="0" /> <!-- Ch 48 MUX-3 DVB-T -->
 	</terrestrial>
 	<terrestrial name="Polska, Ilawa (Europe DVB-T/T2)" flags="5" countrycode="POL">
-		<transponder centre_frequency="198500000" bandwidth="1" constellation="3" system="0" /> <!-- Ch 08 -->
-		<transponder centre_frequency="498000000" bandwidth="0" constellation="3" system="0" /> <!-- Ch 24 -->
-		<transponder centre_frequency="514000000" bandwidth="0" constellation="3" system="0" /> <!-- Ch 26 -->
-		<transponder centre_frequency="610000000" bandwidth="0" constellation="3" system="0" /> <!-- Ch 38 -->
-		<transponder centre_frequency="658000000" bandwidth="0" constellation="3" system="1" /> <!-- Ch 44 DVB-T2 HEVC test emission -->
+		<transponder centre_frequency="198500000" bandwidth="1" constellation="3" system="0" /> <!-- Ch 08 MUX-8 DVB-T -->
+		<transponder centre_frequency="522000000" bandwidth="0" constellation="3" system="1" /> <!-- Ch 27 -->
+		<transponder centre_frequency="594000000" bandwidth="0" constellation="3" system="0" /> <!-- Ch 36 MUX-3 DVB-T -->
+		<transponder centre_frequency="610000000" bandwidth="0" constellation="3" system="1" /> <!-- Ch 38 -->
+		<transponder centre_frequency="650000000" bandwidth="0" constellation="3" system="1" /> <!-- Ch 43 -->
 	</terrestrial>
 	<terrestrial name="Polska, Jelenia Gora (Europe DVB-T/T2)" flags="5" countrycode="POL">
-		<transponder centre_frequency="184500000" bandwidth="1" constellation="3" system="0" /> <!-- Ch 06 -->
-		<transponder centre_frequency="546000000" bandwidth="0" constellation="3" system="0" /> <!-- Ch 30 -->
-		<transponder centre_frequency="586000000" bandwidth="0" constellation="3" system="0" /> <!-- Ch 35 -->
-		<transponder centre_frequency="602000000" bandwidth="0" constellation="3" system="1" /> <!-- Ch 37 DVB-T2 HEVC test emission -->
-		<transponder centre_frequency="698000000" bandwidth="0" constellation="3" system="0" /> <!-- Ch 49 -->
+		<transponder centre_frequency="184500000" bandwidth="1" constellation="3" system="0" /> <!-- Ch 06 MUX-8 DVB-T -->
+		<transponder centre_frequency="498000000" bandwidth="0" constellation="3" system="0" /> <!-- Ch 24 MUX-3 DVB-T -->
+		<transponder centre_frequency="546000000" bandwidth="0" constellation="3" system="1" /> <!-- Ch 30 -->
+		<transponder centre_frequency="602000000" bandwidth="0" constellation="3" system="1" /> <!-- Ch 37 -->
+		<transponder centre_frequency="682000000" bandwidth="0" constellation="3" system="1" /> <!-- Ch 47 -->
 	</terrestrial>
 	<terrestrial name="Polska, Kalisz (Europe DVB-T/T2)" flags="5" countrycode="POL">
-		<transponder centre_frequency="191500000" bandwidth="1" constellation="3" system="0" /> <!-- Ch 07 -->
-		<transponder centre_frequency="514000000" bandwidth="0" constellation="3" system="0" /> <!-- Ch 26 -->
-		<transponder centre_frequency="554000000" bandwidth="0" constellation="3" system="0" /> <!-- Ch 31 -->
-		<transponder centre_frequency="602000000" bandwidth="0" constellation="3" system="1" /> <!-- Ch 37 DVB-T2 HEVC test emission -->
-		<transponder centre_frequency="610000000" bandwidth="0" constellation="3" system="0" /> <!-- Ch 38 -->
-		<transponder centre_frequency="658000000" bandwidth="0" constellation="3" system="0" /> <!-- Ch 44 -->
+		<transponder centre_frequency="191500000" bandwidth="1" constellation="3" system="0" /> <!-- Ch 07 MUX-8 DVB-T -->
+		<transponder centre_frequency="554000000" bandwidth="0" constellation="3" system="0" /> <!-- Ch 31 MUX-3 DVB-T -->
+		<transponder centre_frequency="562000000" bandwidth="0" constellation="3" system="1" /> <!-- Ch 32 -->
+		<transponder centre_frequency="602000000" bandwidth="0" constellation="3" system="1" /> <!-- Ch 37 -->
+		<transponder centre_frequency="658000000" bandwidth="0" constellation="3" system="1" /> <!-- Ch 44 -->
 	</terrestrial>
 	<terrestrial name="Polska, Katowice (Europe DVB-T/T2)" flags="5" countrycode="POL">
-		<transponder centre_frequency="184500000" bandwidth="1" constellation="3" system="0" /> <!-- Ch 06 -->
-		<transponder centre_frequency="474000000" bandwidth="0" constellation="3" system="0" /> <!-- Ch 21 -->
-		<transponder centre_frequency="522000000" bandwidth="0" constellation="3" system="1" /> <!-- Ch 27 DVB-T2 HEVC test emission -->
-		<transponder centre_frequency="626000000" bandwidth="0" constellation="3" system="0" /> <!-- Ch 40 -->
-		<transponder centre_frequency="634000000" bandwidth="0" constellation="3" system="0" /> <!-- Ch 41 -->
-		<transponder centre_frequency="682000000" bandwidth="0" constellation="3" system="0" /> <!-- Ch 47 -->
+		<transponder centre_frequency="184500000" bandwidth="1" constellation="3" system="0" /> <!-- Ch 06 MUX-8 DVB-T -->
+		<transponder centre_frequency="490000000" bandwidth="0" constellation="3" system="1" /> <!-- Ch 23 -->
+		<transponder centre_frequency="498000000" bandwidth="0" constellation="3" system="1" /> <!-- Ch 24 -->
+		<transponder centre_frequency="650000000" bandwidth="0" constellation="3" system="1" /> <!-- Ch 43 -->
+		<transponder centre_frequency="634000000" bandwidth="0" constellation="3" system="0" /> <!-- Ch 41 MUX-3 DVB-T -->
 	</terrestrial>
 	<terrestrial name="Polska, Kielce (Europe DVB-T/T2)" flags="5" countrycode="POL">
-		<transponder centre_frequency="198500000" bandwidth="1" constellation="3" system="0" /> <!-- Ch 08 -->
-		<transponder centre_frequency="546000000" bandwidth="0" constellation="3" system="0" /> <!-- Ch 30 -->
-		<transponder centre_frequency="602000000" bandwidth="0" constellation="3" system="0" /> <!-- Ch 37 -->
-		<transponder centre_frequency="658000000" bandwidth="0" constellation="3" system="1" /> <!-- Ch 44 DVB-T2 HEVC test emission -->
-		<transponder centre_frequency="682000000" bandwidth="0" constellation="3" system="0" /> <!-- Ch 47 -->
+		<transponder centre_frequency="198500000" bandwidth="1" constellation="3" system="0" /> <!-- Ch 08 MUX-8 DVB-T -->
+		<transponder centre_frequency="530000000" bandwidth="0" constellation="3" system="1" /> <!-- Ch 28 -->
+		<transponder centre_frequency="546000000" bandwidth="0" constellation="3" system="1" /> <!-- Ch 30 -->
+		<transponder centre_frequency="658000000" bandwidth="0" constellation="3" system="1" /> <!-- Ch 44 -->
+		<transponder centre_frequency="682000000" bandwidth="0" constellation="3" system="0" /> <!-- Ch 47 MUX-3 DVB-T -->
 	</terrestrial>
 	<terrestrial name="Polska, Koszalin (Europe DVB-T/T2)" flags="5" countrycode="POL">
-		<transponder centre_frequency="191500000" bandwidth="1" constellation="3" system="0" /> <!-- Ch 07 -->
-		<transponder centre_frequency="490000000" bandwidth="0" constellation="3" system="0" /> <!-- Ch 23 -->
-		<transponder centre_frequency="610000000" bandwidth="0" constellation="3" system="0" /> <!-- Ch 38 -->
-		<transponder centre_frequency="658000000" bandwidth="0" constellation="3" system="1" /> <!-- Ch 44 DVB-T2 HEVC test emission -->
-		<transponder centre_frequency="682000000" bandwidth="0" constellation="3" system="0" /> <!-- Ch 47 -->
-		<transponder centre_frequency="690000000" bandwidth="0" constellation="3" system="0" /> <!-- Ch 48 -->
+		<transponder centre_frequency="191500000" bandwidth="1" constellation="3" system="0" /> <!-- Ch 07 MUX-8 DVB-T -->
+		<transponder centre_frequency="490000000" bandwidth="0" constellation="3" system="1" /> <!-- Ch 23 -->
+		<transponder centre_frequency="602000000" bandwidth="0" constellation="3" system="1" /> <!-- Ch 37 -->
+		<transponder centre_frequency="610000000" bandwidth="0" constellation="3" system="0" /> <!-- Ch 38 MUX-3 DVB-T -->
+		<transponder centre_frequency="682000000" bandwidth="0" constellation="3" system="1" /> <!-- Ch 47 -->
+		<transponder centre_frequency="690000000" bandwidth="0" constellation="3" system="0" /> <!-- Ch 48 MUX-3 DVB-T -->
 	</terrestrial>
 	<terrestrial name="Polska, Krakow (Europe DVB-T/T2)" flags="5" countrycode="POL">
-		<transponder centre_frequency="191500000" bandwidth="1" constellation="3" system="0" /> <!-- Ch 07 -->
-		<transponder centre_frequency="482000000" bandwidth="0" constellation="3" system="0" /> <!-- Ch 22 -->
-		<transponder centre_frequency="490000000" bandwidth="0" constellation="3" system="0" /> <!-- Ch 23 -->
-		<transponder centre_frequency="506000000" bandwidth="0" constellation="3" system="0" /> <!-- Ch 25 -->
-		<transponder centre_frequency="522000000" bandwidth="0" constellation="3" system="1" /> <!-- Ch 27 DVB-T2 HEVC test emission -->
+		<transponder centre_frequency="191500000" bandwidth="1" constellation="3" system="0" /> <!-- Ch 07 MUX-8 DVB-T -->
+		<transponder centre_frequency="482000000" bandwidth="0" constellation="3" system="0" /> <!-- Ch 22 MUX-3 DVB-T -->
+		<transponder centre_frequency="490000000" bandwidth="0" constellation="3" system="1" /> <!-- Ch 23 -->
+		<transponder centre_frequency="506000000" bandwidth="0" constellation="3" system="1" /> <!-- Ch 25 -->
+		<transponder centre_frequency="650000000" bandwidth="0" constellation="3" system="1" /> <!-- Ch 43 -->
 	</terrestrial>
 	<terrestrial name="Polska, Lebork (Europe DVB-T/T2)" flags="5" countrycode="POL">
-		<transponder centre_frequency="184500000" bandwidth="1" constellation="3" system="0" /> <!-- Ch 06 -->
-		<transponder centre_frequency="490000000" bandwidth="0" constellation="3" system="0" /> <!-- Ch 23 -->
-		<transponder centre_frequency="498000000" bandwidth="0" constellation="3" system="1" /> <!-- Ch 24 DVB-T2 HEVC test emission -->
-		<transponder centre_frequency="586000000" bandwidth="0" constellation="3" system="0" /> <!-- Ch 35 -->
-		<transponder centre_frequency="602000000" bandwidth="0" constellation="3" system="0" /> <!-- Ch 37 -->
+		<transponder centre_frequency="184500000" bandwidth="1" constellation="3" system="0" /> <!-- Ch 06 MUX-8 DVB-T -->
+		<transponder centre_frequency="498000000" bandwidth="0" constellation="3" system="1" /> <!-- Ch 24 -->
+		<transponder centre_frequency="602000000" bandwidth="0" constellation="3" system="1" /> <!-- Ch 37 -->
+		<transponder centre_frequency="658000000" bandwidth="0" constellation="3" system="1" /> <!-- Ch 44 -->
+		<transponder centre_frequency="690000000" bandwidth="0" constellation="3" system="0" /> <!-- Ch 48 MUX-3 DVB-T -->
 	</terrestrial>
 	<terrestrial name="Polska, Lublin (Europe DVB-T/T2)" flags="5" countrycode="POL">
-		<transponder centre_frequency="226500000" bandwidth="1" constellation="3" system="0" /> <!-- Ch 12 -->
-		<transponder centre_frequency="474000000" bandwidth="0" constellation="3" system="0" /> <!-- Ch 21 -->
-		<transponder centre_frequency="490000000" bandwidth="0" constellation="3" system="0" /> <!-- Ch 23 -->
-		<transponder centre_frequency="506000000" bandwidth="0" constellation="3" system="1" /> <!-- Ch 25 DVB-T2 HEVC test emission -->
-		<transponder centre_frequency="570000000" bandwidth="0" constellation="3" system="0" /> <!-- Ch 33 -->
-		<transponder centre_frequency="650000000" bandwidth="0" constellation="3" system="0" /> <!-- Ch 43 -->
+		<transponder centre_frequency="226500000" bandwidth="1" constellation="3" system="0" /> <!-- Ch 12 MUX-8 DVB-T -->
+		<transponder centre_frequency="490000000" bandwidth="0" constellation="3" system="0" /> <!-- Ch 23 MUX-3 DVB-T -->
+		<transponder centre_frequency="506000000" bandwidth="0" constellation="3" system="1" /> <!-- Ch 25 -->
+		<transponder centre_frequency="586000000" bandwidth="0" constellation="3" system="1" /> <!-- Ch 35 -->
+		<transponder centre_frequency="618000000" bandwidth="0" constellation="3" system="1" /> <!-- Ch 39 -->
 	</terrestrial>
 	<terrestrial name="Polska, Lomza (Europe DVB-T/T2)" flags="5" countrycode="POL">
-		<transponder centre_frequency="226500000" bandwidth="1" constellation="3" system="0" /> <!-- Ch 12 -->
-		<transponder centre_frequency="482000000" bandwidth="0" constellation="3" system="0" /> <!-- Ch 22 -->
-		<transponder centre_frequency="554000000" bandwidth="0" constellation="3" system="1" /> <!-- Ch 31 DVB-T2 HEVC test emission -->
-		<transponder centre_frequency="674000000" bandwidth="0" constellation="3" system="0" /> <!-- Ch 46 -->
-		<transponder centre_frequency="698000000" bandwidth="0" constellation="3" system="0" /> <!-- Ch 49 -->
+		<transponder centre_frequency="226500000" bandwidth="1" constellation="3" system="0" /> <!-- Ch 12 MUX-8 DVB-T -->
+		<transponder centre_frequency="482000000" bandwidth="0" constellation="3" system="1" /> <!-- Ch 22 -->
+		<transponder centre_frequency="586000000" bandwidth="0" constellation="3" system="0" /> <!-- Ch 35 MUX-3 DVB-T -->
+		<transponder centre_frequency="626000000" bandwidth="0" constellation="3" system="1" /> <!-- Ch 40 -->
+		<transponder centre_frequency="650000000" bandwidth="0" constellation="3" system="1" /> <!-- Ch 43 -->
 	</terrestrial>
 	<terrestrial name="Polska, Lodz (Europe DVB-T/T2)" flags="5" countrycode="POL">
-		<transponder centre_frequency="205500000" bandwidth="1" constellation="3" system="0" /> <!-- Ch 09 -->
-		<transponder centre_frequency="498000000" bandwidth="0" constellation="3" system="0" /> <!-- Ch 24 -->
-		<transponder centre_frequency="570000000" bandwidth="0" constellation="3" system="1" /> <!-- Ch 33 DVB-T2 HEVC test emission -->
-		<transponder centre_frequency="650000000" bandwidth="0" constellation="3" system="0" /> <!-- Ch 43 -->
-		<transponder centre_frequency="674000000" bandwidth="0" constellation="3" system="0" /> <!-- Ch 46 -->
+		<transponder centre_frequency="205500000" bandwidth="1" constellation="3" system="0" /> <!-- Ch 09 MUX-8 DVB-T -->
+		<transponder centre_frequency="498000000" bandwidth="0" constellation="3" system="1" /> <!-- Ch 24 -->
+		<transponder centre_frequency="514000000" bandwidth="0" constellation="3" system="0" /> <!-- Ch 26 MUX-3 DVB-T -->
+		<transponder centre_frequency="666000000" bandwidth="0" constellation="3" system="1" /> <!-- Ch 45 -->
+		<transponder centre_frequency="674000000" bandwidth="0" constellation="3" system="1" /> <!-- Ch 46 -->
 	</terrestrial>
 	<terrestrial name="Polska, Miedzyzdroje (Europe DVB-T/T2)" flags="5" countrycode="POL">
-		<transponder centre_frequency="184500000" bandwidth="1" constellation="3" system="0" /> <!-- Ch 06 -->
-		<transponder centre_frequency="474000000" bandwidth="0" constellation="3" system="0" /> <!-- Ch 21 -->
-		<transponder centre_frequency="578000000" bandwidth="0" constellation="3" system="0" /> <!-- Ch 34 -->
-		<transponder centre_frequency="602000000" bandwidth="0" constellation="3" system="1" /> <!-- Ch 37 DVB-T2 HEVC test emission -->
-		<transponder centre_frequency="690000000" bandwidth="0" constellation="3" system="0" /> <!-- Ch 48 -->
+		<transponder centre_frequency="184500000" bandwidth="1" constellation="3" system="0" /> <!-- Ch 06 MUX-8 DVB-T -->
+		<transponder centre_frequency="474000000" bandwidth="0" constellation="3" system="1" /> <!-- Ch 21 -->
+		<transponder centre_frequency="578000000" bandwidth="0" constellation="3" system="1" /> <!-- Ch 34 -->
+		<transponder centre_frequency="602000000" bandwidth="0" constellation="3" system="1" /> <!-- Ch 37 -->
+		<transponder centre_frequency="690000000" bandwidth="0" constellation="3" system="0" /> <!-- Ch 48 MUX-3 DVB-T -->
 	</terrestrial>
 	<terrestrial name="Polska, Olsztyn (Europe DVB-T/T2)" flags="5" countrycode="POL">
-		<transponder centre_frequency="205500000" bandwidth="1" constellation="3" system="0" /> <!-- Ch 09 -->
-		<transponder centre_frequency="514000000" bandwidth="0" constellation="3" system="0" /> <!-- Ch 26 -->
-		<transponder centre_frequency="530000000" bandwidth="0" constellation="3" system="0" /> <!-- Ch 28 -->
-		<transponder centre_frequency="570000000" bandwidth="0" constellation="3" system="0" /> <!-- Ch 33 -->
-		<transponder centre_frequency="666000000" bandwidth="0" constellation="3" system="1" /> <!-- Ch 45 DVB-T2 HEVC test emission -->
+		<transponder centre_frequency="205500000" bandwidth="1" constellation="3" system="0" /> <!-- Ch 09 MUX-8 DVB-T -->
+		<transponder centre_frequency="490000000" bandwidth="0" constellation="3" system="0" /> <!-- Ch 23 MUX-3 DVB-T -->
+		<transponder centre_frequency="514000000" bandwidth="0" constellation="3" system="1" /> <!-- Ch 26 -->
+		<transponder centre_frequency="530000000" bandwidth="0" constellation="3" system="1" /> <!-- Ch 28 -->
+		<transponder centre_frequency="666000000" bandwidth="0" constellation="3" system="1" /> <!-- Ch 45 -->
 	</terrestrial>
 	<terrestrial name="Polska, Opole (Europe DVB-T/T2)" flags="5" countrycode="POL">
-		<transponder centre_frequency="184500000" bandwidth="1" constellation="3" system="0" /> <!-- Ch 06 -->
-		<transponder centre_frequency="490000000" bandwidth="0" constellation="3" system="0" /> <!-- Ch 23 -->
-		<transponder centre_frequency="522000000" bandwidth="0" constellation="3" system="1" /> <!-- Ch 27 DVB-T2 HEVC test emission -->
-		<transponder centre_frequency="538000000" bandwidth="0" constellation="3" system="0" /> <!-- Ch 29 -->
-		<transponder centre_frequency="578000000" bandwidth="0" constellation="3" system="0" /> <!-- Ch 34 -->
+		<transponder centre_frequency="184500000" bandwidth="1" constellation="3" system="0" /> <!-- Ch 06 MUX-8 DVB-T -->
+		<transponder centre_frequency="490000000" bandwidth="0" constellation="3" system="1" /> <!-- Ch 23 -->
+		<transponder centre_frequency="538000000" bandwidth="0" constellation="3" system="1" /> <!-- Ch 29 -->
+		<transponder centre_frequency="578000000" bandwidth="0" constellation="3" system="0" /> <!-- Ch 34 MUX-3 DVB-T -->
+		<transponder centre_frequency="642000000" bandwidth="0" constellation="3" system="1" /> <!-- Ch 42 -->
 	</terrestrial>
 	<terrestrial name="Polska, Pila (Europe DVB-T/T2)" flags="5" countrycode="POL">
-		<transponder centre_frequency="205500000" bandwidth="1" constellation="3" system="0" /> <!-- Ch 09 -->
-		<transponder centre_frequency="554000000" bandwidth="0" constellation="3" system="0" /> <!-- Ch 31 -->
-		<transponder centre_frequency="642000000" bandwidth="0" constellation="3" system="0" /> <!-- Ch 42 -->
-		<transponder centre_frequency="650000000" bandwidth="0" constellation="3" system="0" /> <!-- Ch 43 -->
-		<transponder centre_frequency="658000000" bandwidth="0" constellation="3" system="1" /> <!-- Ch 44 DVB-T2 HEVC test emission -->
+		<transponder centre_frequency="205500000" bandwidth="1" constellation="3" system="0" /> <!-- Ch 09 MUX-8 DVB-T -->
+		<transponder centre_frequency="498000000" bandwidth="0" constellation="3" system="1" /> <!-- Ch 24 -->
+		<transponder centre_frequency="554000000" bandwidth="0" constellation="3" system="0" /> <!-- Ch 31 MUX-3 DVB-T -->
+		<transponder centre_frequency="650000000" bandwidth="0" constellation="3" system="1" /> <!-- Ch 43 -->
+		<transponder centre_frequency="658000000" bandwidth="0" constellation="3" system="1" /> <!-- Ch 44 -->
 	</terrestrial>
 	<terrestrial name="Polska, Poznan (Europe DVB-T/T2)" flags="5" countrycode="POL">
-		<transponder centre_frequency="205500000" bandwidth="1" constellation="3" system="0" /> <!-- Ch 09 -->
-		<transponder centre_frequency="490000000" bandwidth="0" constellation="3" system="0" /> <!-- Ch 23 -->
-		<transponder centre_frequency="522000000" bandwidth="0" constellation="3" system="0" /> <!-- Ch 27 -->
-		<transponder centre_frequency="538000000" bandwidth="0" constellation="3" system="1" /> <!-- Ch 29 DVB-T2 HEVC test emission -->
-		<transponder centre_frequency="618000000" bandwidth="0" constellation="3" system="0" /> <!-- Ch 39 -->
+		<transponder centre_frequency="205500000" bandwidth="1" constellation="3" system="0" /> <!-- Ch 09 MUX-8 DVB-T -->
+		<transponder centre_frequency="490000000" bandwidth="0" constellation="3" system="1" /> <!-- Ch 23 -->
+		<transponder centre_frequency="522000000" bandwidth="0" constellation="3" system="0" /> <!-- Ch 27 MUX-3 DVB-T -->
+		<transponder centre_frequency="538000000" bandwidth="0" constellation="3" system="1" /> <!-- Ch 29 -->
+		<transponder centre_frequency="618000000" bandwidth="0" constellation="3" system="1" /> <!-- Ch 39 -->
 	</terrestrial>
 	<terrestrial name="Polska, Radom (Europe DVB-T/T2)" flags="5" countrycode="POL">
-		<transponder centre_frequency="198500000" bandwidth="1" constellation="3" system="0" /> <!-- Ch 08 -->
-		<transponder centre_frequency="546000000" bandwidth="0" constellation="3" system="0" /> <!-- Ch 30 -->
-		<transponder centre_frequency="602000000" bandwidth="0" constellation="3" system="0" /> <!-- Ch 37 -->
-		<transponder centre_frequency="642000000" bandwidth="0" constellation="3" system="0" /> <!-- Ch 42 -->
-		<transponder centre_frequency="658000000" bandwidth="0" constellation="3" system="1" /> <!-- Ch 44 DVB-T2 HEVC test emission -->
+		<transponder centre_frequency="198500000" bandwidth="1" constellation="3" system="0" /> <!-- Ch 08 MUX-8 DVB-T -->
+		<transponder centre_frequency="514000000" bandwidth="0" constellation="3" system="0" /> <!-- Ch 26 MUX-3 DVB-T -->
+		<transponder centre_frequency="530000000" bandwidth="0" constellation="3" system="1" /> <!-- Ch 28 -->
+		<transponder centre_frequency="546000000" bandwidth="0" constellation="3" system="1" /> <!-- Ch 30 -->
+		<transponder centre_frequency="658000000" bandwidth="0" constellation="3" system="1" /> <!-- Ch 44 -->
 	</terrestrial>
 	<terrestrial name="Polska, Rzeszow (Europe DVB-T/T2)" flags="5" countrycode="POL">
-		<transponder centre_frequency="184500000" bandwidth="1" constellation="3" system="0" /> <!-- Ch 06 -->
-		<transponder centre_frequency="498000000" bandwidth="0" constellation="3" system="1" /> <!-- Ch 24 DVB-T2 HEVC test emission -->
-		<transponder centre_frequency="538000000" bandwidth="0" constellation="3" system="0" /> <!-- Ch 29 -->
-		<transponder centre_frequency="562000000" bandwidth="0" constellation="3" system="0" /> <!-- Ch 32 -->
-		<transponder centre_frequency="690000000" bandwidth="0" constellation="3" system="0" /> <!-- Ch 48 -->
+		<transponder centre_frequency="184500000" bandwidth="1" constellation="3" system="0" /> <!-- Ch 06 MUX-8 DVB-T -->
+		<transponder centre_frequency="538000000" bandwidth="0" constellation="3" system="0" /> <!-- Ch 29 MUX-3 DVB-T -->
+		<transponder centre_frequency="562000000" bandwidth="0" constellation="3" system="1" /> <!-- Ch 32 -->
+		<transponder centre_frequency="586000000" bandwidth="0" constellation="3" system="1" /> <!-- Ch 35 -->
+		<transponder centre_frequency="650000000" bandwidth="0" constellation="3" system="1" /> <!-- Ch 43 -->
 	</terrestrial>
 	<terrestrial name="Polska, Siedlce (Europe DVB-T/T2)" flags="5" countrycode="POL">
-		<transponder centre_frequency="205500000" bandwidth="1" constellation="3" system="0" /> <!-- Ch 09 -->
-		<transponder centre_frequency="594000000" bandwidth="0" constellation="3" system="0" /> <!-- Ch 36 -->
-		<transponder centre_frequency="618000000" bandwidth="0" constellation="3" system="1" /> <!-- Ch 39 DVB-T2 HEVC test emission -->
-		<transponder centre_frequency="650000000" bandwidth="0" constellation="3" system="0" /> <!-- Ch 43 -->
-		<transponder centre_frequency="754000000" bandwidth="0" constellation="3" system="0" /> <!-- Ch 56 -->
+		<transponder centre_frequency="205500000" bandwidth="1" constellation="3" system="0" /> <!-- Ch 09 MUX-8 DVB-T -->
+		<transponder centre_frequency="570000000" bandwidth="0" constellation="3" system="0" /> <!-- Ch 33 MUX-3 DVB-T -->
+		<transponder centre_frequency="594000000" bandwidth="0" constellation="3" system="1" /> <!-- Ch 36 -->
+		<transponder centre_frequency="618000000" bandwidth="0" constellation="3" system="1" /> <!-- Ch 39 -->
+		<transponder centre_frequency="650000000" bandwidth="0" constellation="3" system="1" /> <!-- Ch 43 -->
 	</terrestrial>
 	<terrestrial name="Polska, Suwalki (Europe DVB-T/T2)" flags="5" countrycode="POL">
-		<transponder centre_frequency="191500000" bandwidth="1" constellation="3" system="0" /> <!-- Ch 07 -->
-		<transponder centre_frequency="498000000" bandwidth="0" constellation="3" system="1" /> <!-- Ch 24 DVB-T2 HEVC test emission -->
-		<transponder centre_frequency="538000000" bandwidth="0" constellation="3" system="0" /> <!-- Ch 29 -->
-		<transponder centre_frequency="650000000" bandwidth="0" constellation="3" system="0" /> <!-- Ch 43 -->
-		<transponder centre_frequency="770000000" bandwidth="0" constellation="3" system="0" /> <!-- Ch 58 -->
+		<transponder centre_frequency="191500000" bandwidth="1" constellation="3" system="0" /> <!-- Ch 07 MUX-8 DVB-T -->
+		<transponder centre_frequency="482000000" bandwidth="0" constellation="3" system="1" /> <!-- Ch 22 -->
+		<transponder centre_frequency="538000000" bandwidth="0" constellation="3" system="0" /> <!-- Ch 29 MUX-3 DVB-T -->
+		<transponder centre_frequency="594000000" bandwidth="0" constellation="3" system="1" /> <!-- Ch 36 -->
+		<transponder centre_frequency="650000000" bandwidth="0" constellation="3" system="1" /> <!-- Ch 43 -->
 	</terrestrial>
 	<terrestrial name="Polska, Szczecin (Europe DVB-T/T2)" flags="5" countrycode="POL">
-		<transponder centre_frequency="184500000" bandwidth="1" constellation="3" system="0" /> <!-- Ch 06 -->
-		<transponder centre_frequency="578000000" bandwidth="0" constellation="3" system="0" /> <!-- Ch 34 -->
-		<transponder centre_frequency="602000000" bandwidth="0" constellation="3" system="1" /> <!-- Ch 37 DVB-T2 HEVC test emission -->
-		<transponder centre_frequency="634000000" bandwidth="0" constellation="3" system="0" /> <!-- Ch 41 -->
-		<transponder centre_frequency="690000000" bandwidth="0" constellation="3" system="0" /> <!-- Ch 48 -->
+		<transponder centre_frequency="184500000" bandwidth="1" constellation="3" system="0" /> <!-- Ch 06 MUX-8 DVB-T -->
+		<transponder centre_frequency="578000000" bandwidth="0" constellation="3" system="1" /> <!-- Ch 34 -->
+		<transponder centre_frequency="602000000" bandwidth="0" constellation="3" system="1" /> <!-- Ch 37 -->
+		<transponder centre_frequency="634000000" bandwidth="0" constellation="3" system="1" /> <!-- Ch 41 -->
+		<transponder centre_frequency="690000000" bandwidth="0" constellation="3" system="0" /> <!-- Ch 48 MUX-3 DVB-T -->
 	</terrestrial>
 	<terrestrial name="Polska, Warszawa (Europe DVB-T/T2)" flags="5" countrycode="POL">
-		<transponder centre_frequency="191500000" bandwidth="1" constellation="3" system="0" /> <!-- Ch 07 -->
-		<transponder centre_frequency="522000000" bandwidth="0" constellation="3" system="0" /> <!-- Ch 27 -->
-		<transponder centre_frequency="554000000" bandwidth="0" constellation="3" system="1" /> <!-- Ch 31 DVB-T2 HEVC test emission -->
-		<transponder centre_frequency="690000000" bandwidth="0" constellation="3" system="0" /> <!-- Ch 48 -->
-		<transponder centre_frequency="770000000" bandwidth="0" constellation="3" system="0" /> <!-- Ch 58 -->
+		<transponder centre_frequency="191500000" bandwidth="1" constellation="3" system="0" /> <!-- Ch 07 MUX-8 DVB-T -->
+		<transponder centre_frequency="522000000" bandwidth="0" constellation="3" system="0" /> <!-- Ch 27 MUX-3 DVB-T -->
+		<transponder centre_frequency="538000000" bandwidth="0" constellation="3" system="1" /> <!-- Ch 29 -->
+		<transponder centre_frequency="650000000" bandwidth="0" constellation="3" system="1" /> <!-- Ch 43 -->
+		<transponder centre_frequency="690000000" bandwidth="0" constellation="3" system="1" /> <!-- Ch 48 -->
 	</terrestrial>
 	<terrestrial name="Polska, Wroclaw (Europe DVB-T/T2)" flags="5" countrycode="POL">
-		<transponder centre_frequency="184500000" bandwidth="1" constellation="3" system="0" /> <!-- Ch 06 -->
-		<transponder centre_frequency="498000000" bandwidth="0" constellation="3" system="0" /> <!-- Ch 24 -->
-		<transponder centre_frequency="506000000" bandwidth="0" constellation="3" system="0" /> <!-- Ch 25 -->
-		<transponder centre_frequency="570000000" bandwidth="0" constellation="3" system="0" /> <!-- Ch 33 -->
-		<transponder centre_frequency="602000000" bandwidth="0" constellation="3" system="1" /> <!-- Ch 37 DVB-T2 HEVC test emission -->
-		<transponder centre_frequency="674000000" bandwidth="0" constellation="3" system="0" /> <!-- Ch 46 -->
+		<transponder centre_frequency="184500000" bandwidth="1" constellation="3" system="0" /> <!-- Ch 06 MUX-8 DVB-T -->
+		<transponder centre_frequency="506000000" bandwidth="0" constellation="3" system="0" /> <!-- Ch 25 MUX-3 DVB-T -->
+		<transponder centre_frequency="570000000" bandwidth="0" constellation="3" system="1" /> <!-- Ch 33 -->
+		<transponder centre_frequency="674000000" bandwidth="0" constellation="3" system="1" /> <!-- Ch 46 -->
+		<transponder centre_frequency="682000000" bandwidth="0" constellation="3" system="1" /> <!-- Ch 47 -->
 	</terrestrial>
 	<terrestrial name="Polska, Zakopane (Europe DVB-T/T2)" flags="5" countrycode="POL">
-		<transponder centre_frequency="191500000" bandwidth="1" constellation="3" system="0" /> <!-- Ch 07 -->
-		<transponder centre_frequency="530000000" bandwidth="0" constellation="3" system="1" /> <!-- Ch 28 DVB-T2 HEVC test emission -->
-		<transponder centre_frequency="578000000" bandwidth="0" constellation="3" system="0" /> <!-- Ch 34 -->
-		<transponder centre_frequency="594000000" bandwidth="0" constellation="3" system="0" /> <!-- Ch 36 -->
-		<transponder centre_frequency="650000000" bandwidth="0" constellation="3" system="0" /> <!-- Ch 43 -->
+		<transponder centre_frequency="191500000" bandwidth="1" constellation="3" system="0" /> <!-- Ch 07 MUX-8 DVB-T -->
+		<transponder centre_frequency="530000000" bandwidth="0" constellation="3" system="1" /> <!-- Ch 28 -->
+		<transponder centre_frequency="578000000" bandwidth="0" constellation="3" system="0" /> <!-- Ch 34 MUX-3 DVB-T -->
+		<transponder centre_frequency="594000000" bandwidth="0" constellation="3" system="1" /> <!-- Ch 36 -->
+		<transponder centre_frequency="650000000" bandwidth="0" constellation="3" system="1" /> <!-- Ch 43 -->
 	</terrestrial>
 	<terrestrial name="Polska, Zamosc (Europe DVB-T/T2)" flags="5" countrycode="POL">
-		<transponder centre_frequency="226500000" bandwidth="1" constellation="3" system="0" /> <!-- Ch 12 -->
-		<transponder centre_frequency="562000000" bandwidth="0" constellation="3" system="0" /> <!-- Ch 32 -->
-		<transponder centre_frequency="578000000" bandwidth="0" constellation="3" system="0" /> <!-- Ch 34 -->
-		<transponder centre_frequency="594000000" bandwidth="0" constellation="3" system="0" /> <!-- Ch 36 -->
-		<transponder centre_frequency="618000000" bandwidth="0" constellation="3" system="1" /> <!-- Ch 39 DVB-T2 HEVC test emission -->
+		<transponder centre_frequency="226500000" bandwidth="1" constellation="3" system="0" /> <!-- Ch 12 MUX-8 DVB-T -->
+		<transponder centre_frequency="578000000" bandwidth="0" constellation="3" system="1" /> <!-- Ch 34 -->
+		<transponder centre_frequency="586000000" bandwidth="0" constellation="3" system="1" /> <!-- Ch 35 -->
+		<transponder centre_frequency="594000000" bandwidth="0" constellation="3" system="0" /> <!-- Ch 36 MUX-3 DVB-T -->>
+		<transponder centre_frequency="618000000" bandwidth="0" constellation="3" system="1" /> <!-- Ch 39 -->
 	</terrestrial>
 	<terrestrial name="Polska, Zielona Gora (Europe DVB-T/T2)" flags="5" countrycode="POL">
-		<transponder centre_frequency="198500000" bandwidth="1" constellation="3" system="0" /> <!-- Ch 08 -->
-		<transponder centre_frequency="474000000" bandwidth="0" constellation="3" system="0" /> <!-- Ch 21 -->
-		<transponder centre_frequency="562000000" bandwidth="0" constellation="3" system="0" /> <!-- Ch 32 -->
-		<transponder centre_frequency="610000000" bandwidth="0" constellation="3" system="1" /> <!-- Ch 38 DVB-T2 HEVC test emission -->
-		<transponder centre_frequency="666000000" bandwidth="0" constellation="3" system="0" /> <!-- Ch 45 -->
+		<transponder centre_frequency="198500000" bandwidth="1" constellation="3" system="0" /> <!-- Ch 08 MUX-8 DVB-T -->
+		<transponder centre_frequency="474000000" bandwidth="0" constellation="3" system="1" /> <!-- Ch 21 -->
+		<transponder centre_frequency="546000000" bandwidth="0" constellation="3" system="1" /> <!-- Ch 30 -->
+		<transponder centre_frequency="562000000" bandwidth="0" constellation="3" system="1" /> <!-- Ch 32 MUX-3 DVB-T -->
+		<transponder centre_frequency="666000000" bandwidth="0" constellation="3" system="1" /> <!-- Ch 45 -->
 	</terrestrial>
 	<terrestrial name="Portugal (Europe DVB-T)" flags="5" countrycode="PRT">
 		<!-- https://tdt.telecom.pt/emissores -->


### PR DESCRIPTION
* [PL] Add Rzeszow

* PL: end test emission DVB-T2 HEVC private provider

* Changes on Polish DVB-T/T2: refarming, switch to DVB-T2/HEVC (without MUX-8 and MUX-3)